### PR TITLE
Identifier bug fix, patch to incompetent parser

### DIFF
--- a/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_optimizer.cpp
+++ b/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_optimizer.cpp
@@ -445,8 +445,8 @@ int BlockFusionWavefrontOptimizer::FuseGroupOnGraph(const std::shared_ptr<Fusion
                 auto node = m_nodes[group->nodes.at(i)]->node;
                 std::shared_ptr<KernelContext> ctx(new KernelContext(node));
                 std::string identifier = generate_identifier(ctx);
-                std::set<std::string> tags = {"fast"};
-                auto fetched_kernel = m_kernel_db->fetch_with_tags(identifier, "CUDA", tags, true);
+                auto fetched_kernel =
+                    m_kernel_db->fetch_with_tags(identifier, "CUDA", set<string>{}, true);
                 if (fetched_kernel.function != "")
                 {
                     auto kernel = std::make_shared<kernels::cuda::CacheBlockCudaKernel>(

--- a/src/nnfusion/engine/pass/graph/dot_transpose_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/dot_transpose_pass.cpp
@@ -176,10 +176,10 @@ bool DotTransposePass::run_on_graph(std::shared_ptr<nnfusion::graph::Graph>& gra
 
         auto platform = devtype2platform((*it)["DeviceType"].as<NNFusion_DeviceType>());
         auto product_name = get_product_name();
-        nnfusion::cache::kernel dot_kernel = fetch_best_kernel(
-            identifier, platform, set<string>{"fast"}, cache_manager, product_name);
+        nnfusion::cache::kernel dot_kernel =
+            fetch_best_kernel(identifier, platform, set<string>{}, cache_manager, product_name);
         nnfusion::cache::kernel transpose_dot_kernel = fetch_best_kernel(
-            identifier, platform, set<string>{"fast", "transB"}, cache_manager, product_name);
+            identifier, platform, set<string>{"transB"}, cache_manager, product_name);
         // no profiling time
         if (dot_kernel.profile.find(product_name) == dot_kernel.profile.end() ||
             transpose_dot_kernel.profile.find(product_name) == transpose_dot_kernel.profile.end())

--- a/src/nnfusion/engine/pass/graph/pattern_substitution.cpp
+++ b/src/nnfusion/engine/pass/graph/pattern_substitution.cpp
@@ -25,7 +25,7 @@ const static std::vector<std::vector<std::string>> PATTERNS = {
     // {"Convolution", "BatchNormInference", "Relu"},
     // {"Convolution", "BatchNormInference", "Add"},
     // {"Convolution", "BatchNormInference"},
-    // {"Convolution", "Add", "Reshape", "Relu"},
+    // Conv-BN-Relu is converted into Conv-Add-Relu
     {"Convolution", "Add", "Relu"},
     {"Convolution", "Relu"}};
 

--- a/src/nnfusion/engine/pass/graph/pattern_substitution.cpp
+++ b/src/nnfusion/engine/pass/graph/pattern_substitution.cpp
@@ -139,7 +139,7 @@ private:
         if (identifier != "")
         {
             // Todo: more tags, more platform
-            std::set<std::string> tags = {"fast"};
+            std::set<std::string> tags = {};
             auto fetched_kernel = kernel_db->fetch_with_tags(identifier, "CUDA", tags);
             if (fetched_kernel.function != "")
             {

--- a/src/tools/nnfusion/kernel_db/convert_tvm.py
+++ b/src/tools/nnfusion/kernel_db/convert_tvm.py
@@ -4,7 +4,7 @@
 """
 This script helps you to insert specific kernels (specs in json files) into our kernel_db
 Some more explains to customize it for your needs
-    parameters : specify the parameters and their data types for a certain type of kernel
+    param_list : specify the parameters and their data types for a certain type of kernel
     gen_key    : generate identifier of kernel specification, including I/O shapes, types and more
     gen_config : convert kernel specification to the db format 
     insert_db  : insert the parsed kernel into kernel db
@@ -24,7 +24,7 @@ db_name = "kernel_cache.db"
 
 
 # Todo: re-org operator definition to oop and coordinate to NNFusion
-parameters = {
+param_list = {
     "Convolution": {
         'symbol': ['input0', 'input1', 'output0'],
         'dtype': ['float*', 'float*', 'float*']
@@ -72,7 +72,7 @@ def gen_key(data, dtype="float"):
     op_type = data["op_type"]
     in_shape = data["in_shape"]
     out_shape = data["out_shape"]
-    parameters = data["parameters"]
+    parameters = data["parameters"] if "parameters" in data else {}
 
     key = op_type
     key += ";".join(",".join(str(i) for i in shape) for shape in in_shape)
@@ -110,7 +110,7 @@ def gen_key(data, dtype="float"):
         key += "Shape{" + ", ".join(str(i)
                                     for i in parameters["padding_below"]) + "}"
     else:
-        raise ("not implemented")
+        pass
 
     return key
 
@@ -213,7 +213,7 @@ if __name__ == '__main__':
 
         # parse and clean up the cuda code to get some specific information
         shared_memory, new_code, sync_code, signature = code_parse(
-            kernel["code"], parameters[op_type])
+            kernel["code"], param_list[op_type])
 
         config = gen_config(op_type, kernel, shared_memory, num_sync=0)
 

--- a/src/tools/nnfusion/kernel_db/convert_tvm.py
+++ b/src/tools/nnfusion/kernel_db/convert_tvm.py
@@ -16,7 +16,7 @@ import sqlite3
 import os
 import math
 
-from cuparse import parse as code_parse
+from reparse import parse as code_parse
 from profile import prepare_file, profile, prod
 
 db_path = os.environ['HOME'] + "/.cache/nnfusion/"
@@ -45,11 +45,11 @@ parameters = {
         'symbol': ['input0', 'input1', 'output0'],
         'dtype': ['float*', 'float*', 'float*']
     },
-    "Fused_Convolution_Batchnorm_Relu": {
+    "Fused_Convolution_Batchnorm": {
         'symbol': ['input0', 'input1', 'output0', 'input2'],
         'dtype': ['float*', 'float*', 'float*', 'float*']
     },
-    "Fused_Convolution_Batchnorm": {
+    "Fused_Convolution_Batchnorm_Relu": {
         'symbol': ['input0', 'input1', 'output0', 'input2'],
         'dtype': ['float*', 'float*', 'float*', 'float*']
     },
@@ -63,51 +63,51 @@ parameters = {
     }
 }
 
+conv_augmented = ["Fused_Convolution_Batchnorm", "Fused_Convolution_Batchnorm_Relu", "Fused_Convolution_Add_Relu"]
+conv_family = ["Convolution", "Fused_Convolution_Relu"] + conv_augmented
 
 def gen_key(data, dtype="float"):
     op_type = data["op_type"]
     in_shape = data["in_shape"]
     out_shape = data["out_shape"]
-    key = op_type
-    key += "".join("".join(str(i) for i in shape) for shape in in_shape)
-    if op_type != "Fused_Convolution_Add_Relu":
-        key += "".join("".join(str(i) for i in shape) for shape in out_shape)
-        key += "float" * (len(in_shape) + len(out_shape))
-    else:
-        key += "float" * len(in_shape)
+    parameters = data["parameters"]
 
-    if op_type in [
-            "Convolution", "Fused_Convolution_Relu", "Fused_Convolution_Batchnorm", "Fused_Convolution_Batchnorm_Relu",
-            "Fused_Convolution_Add_Relu"
-    ]:
-        parameters = data["parameters"]
+    key = op_type
+    key += ";".join(",".join(str(i) for i in shape) for shape in in_shape)
+    if op_type in augmented_conv:
+        key += "float" * len(in_shape)
+    else:
+        key += ";".join(",".join(str(i) for i in shape) for shape in out_shape)
+        key += "float" * (len(in_shape) + len(out_shape))
+
+    if op_type in conv_family:
         key += "".join(["Strides{", ", ".join(str(i)
                                               for i in parameters["window_movement_strides"]), "}"])
         key += "".join(["Strides{", ", ".join(str(i)
                                               for i in parameters["window_dilation_strides"]), "}"])
         key += "".join(["CoordinateDiff{", ", ".join(str(i)
                                                      for i in parameters["padding_below_diff"]), "}"])
-        if op_type != "Convolution":
-            key = key.replace(op_type, "Convolution")
-            for op in op_type.split("_"):
-                if op == "Batchnorm":
-                    raise ("to be specified")
-                elif op == "Add":
-                    key += "Add" + "".join("".join(str(i) for i in shape)
-                                           for shape in out_shape) * 3 + "float" * 3 * len(out_shape)
-                elif op == "Relu":
-                    key += "Relu" + "".join("".join(str(i) for i in shape)
-                                            for shape in out_shape) * 2 + "float" * 2 * len(out_shape)
-                elif op not in ["Fused", "Convolution"]:
-                    raise ("not implemented")
+        key = key.replace(op_type, "Convolution")
+        for op in op_type.split("_"):
+            if op in ["Fused", "Convolution"]:
+                pass
+            elif op == "Add":
+                key += "Add" + ";".join(",".join(str(i) for i in shape)
+                                        for shape in out_shape) * 3 + "float" * 3 * len(out_shape)
+            elif op == "Relu":
+                key += "Relu" + ";".join(",".join(str(i) for i in shape)
+                                        for shape in out_shape) * 2 + "float" * 2 * len(out_shape)
+            else:
+                raise ("to be specified")
     elif op_type == "AvgPool" or op_type == "MaxPool":
-        parameters = data["parameters"]
         key += "Shape{" + ", ".join(str(i)
                                     for i in parameters["window_shape"]) + "}"
         key += "Strides{" + ", ".join(str(i)
                                       for i in parameters["window_stride"]) + "}"
         key += "Shape{" + ", ".join(str(i)
                                     for i in parameters["padding_below"]) + "}"
+    else:
+        raise ("not implemented")
 
     return key
 
@@ -122,11 +122,7 @@ def gen_config(op_type, kernel, shared_memory, num_sync):
         "blockDim": kernel["blockDim"],
         "gridDim": kernel["gridDim"],
     }
-    if op_type in [
-            "Convolution", "Fused_Convolution_Relu", "Fused_Convolution_Batchnorm", "Fused_Convolution_Batchnorm_Relu",
-            "Fused_Convolution_Add_Relu"
-    ]:
-        config["function_sig"] = "extern \"C\" __global__  void (float* input0, float* input1, float* output0)"
+    if op_type in conv_family:
         config["in_shape"] = [kernel["parameters"]
                               ["input_shape"], kernel["parameters"]["filter_shape"]]
         config["out_shape"] = [kernel["parameters"]["output_shape"]]
@@ -135,14 +131,12 @@ def gen_config(op_type, kernel, shared_memory, num_sync):
             "window_dilation_strides": kernel["parameters"]["window_dilation_strides"],
             "padding_below_diff": kernel["parameters"]["padding_below_diff"]
         }
-        if "Batchnorm" in op_type or "Add" in op_type:
-            if "Batchnorm" in op_type and "Add" in op_type:
-                config[
-                    "function_sig"] = "extern \"C\" __global__  void (float* input0, float* input1, float* input2, float* input3, float* output0)"
-            else:
-                config["in_shape"].append(config["out_shape"][0])
-                config[
-                    "function_sig"] = "extern \"C\" __global__  void (float* input0, float* input1, float* input2, float* output0)"
+        if op_type in conv_augmented:
+            config["in_shape"].append(config["out_shape"][0])
+            config[
+                "function_sig"] = "extern \"C\" __global__  void (float* input0, float* input1, float* input2, float* output0)"
+        else:
+            config["function_sig"] = "extern \"C\" __global__  void (float* input0, float* input1, float* output0)"
     elif (op_type == "Dot"):
         config["in_shape"] = [kernel["parameters"]
                               ["arg0_shape"], kernel["parameters"]["arg1_shape"]]
@@ -168,7 +162,7 @@ def gen_config(op_type, kernel, shared_memory, num_sync):
     return config
 
 
-def insert_db(name, platform="CUDA", tags="fast", profile="Tesla V100-PCIE-16GB:1", resource=0):
+def insert_db(name, resource, platform="CUDA", tags="", profile="Tesla V100-PCIE-16GB:1"):
     # Todo: More tags could be used to store multiple implementations with the same kernel specs
     in_file = open(name + ".cu")
     json_file = open(name + ".json")
@@ -215,8 +209,10 @@ if __name__ == '__main__':
         op_type = kernel["op_type"]
 
         # parse and clean up the cuda code to get some specific information
-        shared_memory, num_sync, new_code, signature = code_parse(
-            kernel["code"], parameters[op_type])
+        shared_memory, new_code, signature = code_parse(kernel["code"], parameters[op_type])
+
+        prepare_file(signature, kernel["code"], config, db_path + "profile/", parse=True)
+        num_sync = log_sync(signature, db_path + "profile/")
 
         config = gen_config(op_type, kernel, shared_memory, num_sync)
 
@@ -230,16 +226,17 @@ if __name__ == '__main__':
         with open(operator_path + name + ".cu", "w+") as f:
             f.write(new_code)
 
-        default_tags = "fast"
+        default_tags = ""
         if (op_type == "Dot"):
+            # Todo: move the transpose information into identifier
             default_tags += kernel["parameters"]["transpose_A"] * \
                 ",transA" + kernel["parameters"]["transpose_B"]*",transB"
 
         # apply rules that every 32 threads will be formed as a warp
         resource = math.ceil(
             prod(config["blockDim"])/32)*32 * prod(config["gridDim"])
+
         prepare_file(signature, kernel["code"], config, db_path + "profile/")
         profile_info = profile(signature, db_path + "profile/")
         print(profile_info, resource)
-        insert_db(operator_path + name,
-                  tags=default_tags, profile=profile_info, resource=resource)
+        insert_db(operator_path + name, resource, tags=default_tags, profile=profile_info)

--- a/src/tools/nnfusion/kernel_db/cuparse.py
+++ b/src/tools/nnfusion/kernel_db/cuparse.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 """
+This incompetent parser has been deprecated
 Basic lexer and parser needed
 pip install ply
 """

--- a/src/tools/nnfusion/kernel_db/insert_db.sh
+++ b/src/tools/nnfusion/kernel_db/insert_db.sh
@@ -1,9 +1,0 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-
-JSONS=../../../../artifacts/kernel_db/rammer_kernels/*.json
-
-for f in $JSONS
-do
-    python convert_tvm.py $f
-done

--- a/src/tools/nnfusion/kernel_db/profile.py
+++ b/src/tools/nnfusion/kernel_db/profile.py
@@ -11,7 +11,7 @@ def prod(a):
     return reduce((lambda x, y: x * y), a)
 
 
-def prepare_file(signature, code, config, path):
+def prepare_file(signature, code, config, path, parse=False):
     kernel_cuh = r'''
 #pragma once
 
@@ -34,6 +34,8 @@ def prepare_file(signature, code, config, path):
       throw std::runtime_error(safe_call_ss.str());                    \
     }                                                                  \
   } while (0)
+
+#define __LOGSYNC() {__syncthreads(); SYNC_COUNT++;}
 
 __placeholder__
 
@@ -77,7 +79,7 @@ __init_input__
   }
 
   // kernel call
-  int steps = 100;
+  int steps = __step__;
   cudaProfilerStart();
   for (int i_ = 0; i_ < steps; i_++) {
     __signature__<<<
@@ -88,7 +90,8 @@ __init_input__
   CUDA_SAFE_CALL(cudaFree(memory_pool));
 
   return 0;
-}'''
+}'''.replace("__step__", 1 if parse else 100)
+
     bytes_count = [0]
     for shape in config["in_shape"]+config["out_shape"]:
         bytes_count.append(prod(shape)*4 + bytes_count[-1])
@@ -117,6 +120,14 @@ __init_input__
     with open(path + "profile_kernel.cu", "w+") as f:
         f.write(profile_kernel)
 
+
+def log_sync(kernel, path):
+    command = ["make; ./profile"]
+    process = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=path, shell=True)
+    syncthreads, _ = process.communicate()
+    num_sync = re.compile(r'Amount of syncthreads logged: (\d+)')
+    return num_sync.search(str(syncthreads)).group(1)
 
 def profile(kernel, path):
     command = ["make; nvprof --normalized-time-unit us --csv ./profile"]

--- a/src/tools/nnfusion/kernel_db/profile.py
+++ b/src/tools/nnfusion/kernel_db/profile.py
@@ -35,8 +35,6 @@ def prepare_file(signature, code, config, path, parse=False):
     }                                                                  \
   } while (0)
 
-#define __LOGSYNC() {__syncthreads(); SYNC_COUNT++;}
-
 __placeholder__
 
 extern "C" void cuda_init() {
@@ -90,7 +88,7 @@ __init_input__
   CUDA_SAFE_CALL(cudaFree(memory_pool));
 
   return 0;
-}'''.replace("__step__", 1 if parse else 100)
+}'''.replace("__step__", "1" if parse else "100")
 
     bytes_count = [0]
     for shape in config["in_shape"]+config["out_shape"]:
@@ -128,6 +126,7 @@ def log_sync(kernel, path):
     syncthreads, _ = process.communicate()
     num_sync = re.compile(r'Amount of syncthreads logged: (\d+)')
     return num_sync.search(str(syncthreads)).group(1)
+
 
 def profile(kernel, path):
     command = ["make; nvprof --normalized-time-unit us --csv ./profile"]

--- a/src/tools/nnfusion/kernel_db/reparse.py
+++ b/src/tools/nnfusion/kernel_db/reparse.py
@@ -1,7 +1,0 @@
-import re
-
-func = re.compile(r'(.*__global__\s+void\s+([A-Za-z_]\w*)\s*\(.*\))\s*({.*\Z)')
-shared_mem = re.compile(r'__shared__\s+([A-Za-z_]\w*)\s+([A-Za-z_]\w*)\s*\[\s*(\d+)\s*\]\s*;')
-
-def parse(code, parameters):
-    for (i, dtype) in enumerate(parameters["dtype"]):

--- a/src/tools/nnfusion/kernel_db/reparse.py
+++ b/src/tools/nnfusion/kernel_db/reparse.py
@@ -1,0 +1,7 @@
+import re
+
+func = re.compile(r'(.*__global__\s+void\s+([A-Za-z_]\w*)\s*\(.*\))\s*({.*\Z)')
+shared_mem = re.compile(r'__shared__\s+([A-Za-z_]\w*)\s+([A-Za-z_]\w*)\s*\[\s*(\d+)\s*\]\s*;')
+
+def parse(code, parameters):
+    for (i, dtype) in enumerate(parameters["dtype"]):


### PR DESCRIPTION
- `identifier` are now generated in a join manner to resolve this issue: https://github.com/microsoft/nnfusion/issues/30
- `__syncthreads()` are now counted by logging execution instead of static analysis to resolve known bugs related to original parser
- Default `tags` for cached kernels are now set to be an empty set
- Some other minor improvements