### PR TITLE
Fix static cuda path issue

### DIFF
--- a/src/nnfusion/engine/pass/codegen/codegen_langunit.cpp
+++ b/src/nnfusion/engine/pass/codegen/codegen_langunit.cpp
@@ -64,7 +64,7 @@ target_link_libraries(${TARGET_NAME}
 
 LU_DEFINE(nnfusion::codegen::cmake::cuda_lib,
           R"(
-link_directories(/usr/local/cuda/lib64)
+link_directories(${CUDA_TOOLKIT_ROOT_DIR}/lib64)
 
 find_path(CUDNN_INCLUDE_DIR cudnn.h
     HINTS ${CUDA_TOOLKIT_ROOT_DIR}
@@ -76,8 +76,8 @@ find_library(CUDNN_LIBRARY cudnn
     HINTS ${CUDA_TOOLKIT_ROOT_DIR}
     PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
 
-find_library(CUDA_cuda_LIBRARY cuda /usr/local/cuda/lib64/stubs)
-find_library(CUDA_cudart_LIBRARY libcudart.so /usr/local/cuda/lib64)
+find_library(CUDA_cuda_LIBRARY cuda ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs)
+find_library(CUDA_cudart_LIBRARY libcudart.so ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
 
 target_link_libraries(${TARGET_NAME}
     ${CUDA_cuda_LIBRARY}

--- a/src/nnfusion/engine/pass/codegen/cuda_codegen_pass.cpp
+++ b/src/nnfusion/engine/pass/codegen/cuda_codegen_pass.cpp
@@ -1049,6 +1049,7 @@ cmake_minimum_required(VERSION 3.5)
 
 SET(SRC "nnfusion_rt.cu" CACHE STRING "codegen source file")
 SET(TARGET_NAME "nnfusion_naive_rt" CACHE STRING "codegen target name")
+SET(CUDA_ARCH "-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75" CACHE STRING "target architecture")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -1059,7 +1060,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
 find_package(CUDA)
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75")
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${CUDA_ARCH}")
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -O2")
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -cudart shared")
 )";


### PR DESCRIPTION
Fixed #49 by changing the /usr/local/cuda path into a cmake variable ${CUDA_TOOLKIT_ROOT_DIR}
Also solved #66 by changing the pre-set arch command into a user editable parameter