### PR TITLE
BlockFusion correctness check

### DIFF
--- a/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_optimizer.cpp
+++ b/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_optimizer.cpp
@@ -28,8 +28,9 @@ BlockFusionWavefrontOptimizer::BlockFusionWavefrontOptimizer(std::shared_ptr<Gra
                                                              std::string _device_type,
                                                              std::string _device_name,
                                                              int _fusion_level,
-                                                             bool _flag_interplay)
-    : BlockFusionOptimizer(g, _device_type)
+                                                             bool _flag_interplay,
+                                                             bool _flag_check_correctness)
+    : BlockFusionOptimizer(g, _device_type, _flag_check_correctness)
 {
     m_nodes.resize(m_graph->get_max_node_id());
     m_device_name = _device_name;
@@ -342,7 +343,10 @@ void BlockFusionWavefrontOptimizer::MergeGroups(
             double merged_result = GroupProfiler(merged);
             NNFUSION_LOG(INFO) << "runtime profiler, merged " << merged_result << "\n";
             NNFUSION_LOG(INFO) << "runtime profiler, original " << result + cur_result << "\n";
-            if (merged_result < result + cur_result)
+
+            // merged_result == 0 may indicate kernel failure during execution
+            if (merged_result < result + cur_result &&
+                std::abs(merged_result - (double)0.0) > (double)1e-5)
             {
                 groups->at(group_index - 1) = merged;
                 groups->erase(groups->begin() + group_index);
@@ -420,6 +424,25 @@ bool BlockFusionWavefrontOptimizer::SkipGroupOnProfilingResult(
                 << "BlockFusion: skip group, fused_estimation_time >= normal_execution_time";
             return true;
         }
+    }
+
+    if (profiling_result.profile_codegen)
+    {
+        // skip group when fused_execution_time == 0 which may indicate kernel execution failure
+        if (std::abs(profiling_result.fused_execution_time - (double)0.0) < (double)1e-5)
+        {
+            NNFUSION_LOG(INFO) << "BlockFusion: skip group, fused_execution_time == 0, which may "
+                                  "indicate kernel execution failure";
+            return true;
+        }
+
+        // skip group when fused_execution_time > normal_execution_time
+        // if (profiling_result.fused_execution_time > profiling_result.normal_execution_time)
+        // {
+        //     NNFUSION_LOG(INFO)
+        //         << "BlockFusion: skip group, fused_execution_time > normal_execution_time";
+        //     return true;
+        // }
     }
 
     return false;
@@ -517,10 +540,15 @@ int BlockFusionWavefrontOptimizer::FuseGroupOnGraph(const std::shared_ptr<Fusion
     auto kernel = std::dynamic_pointer_cast<KernelEmitter>(code_generator_p);
     auto ctx = code_generator.get_kernel_context();
 
-    if (m_fusion_level >= 2)
+    if (m_check_correctness || m_fusion_level >= 2)
     {
         blockfusion_profiler.set_profiling_context(virtual_device_p, code_generator_p);
-        if (SkipGroupOnProfilingResult(blockfusion_profiler.get_profiling_result()))
+        auto profiling_result = blockfusion_profiler.get_profiling_result();
+        if (!profiling_result.profile_codegen)
+        {
+            return -1;
+        }
+        if (SkipGroupOnProfilingResult(profiling_result))
         {
             return -1;
         }

--- a/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_optimizer.hpp
+++ b/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_optimizer.hpp
@@ -15,7 +15,9 @@ using namespace nnfusion;
 class BlockFusionOptimizer
 {
 public:
-    BlockFusionOptimizer(std::shared_ptr<nnfusion::graph::Graph> g, std::string _device_type)
+    BlockFusionOptimizer(std::shared_ptr<nnfusion::graph::Graph> g,
+                         std::string _device_type,
+                         bool _flag_check_correctness)
         : m_graph(g)
         , m_device_type(_device_type)
     {
@@ -33,6 +35,8 @@ public:
                 << "BlockFusion does not support " << m_device_type
                 << " now, BlockFusion will be disabled in this compilation.";
         }
+
+        m_check_correctness = _flag_check_correctness;
     }
 
     virtual bool Optimize()
@@ -48,6 +52,7 @@ protected:
     std::shared_ptr<nnfusion::graph::Graph> m_graph;
     std::string m_device_type;
     bool m_enable_blockfusion;
+    bool m_check_correctness; // check the correctness of BlockFusion codegen
 };
 
 class BlockFusionWavefrontOptimizer : public BlockFusionOptimizer
@@ -57,7 +62,8 @@ public:
                                   std::string _device_type,
                                   std::string _device_name,
                                   int _fusion_level = 1,
-                                  bool _flag_interplay = true);
+                                  bool _flag_interplay = true,
+                                  bool _flag_check_correctness = false);
 
     bool Optimize() override;
 

--- a/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_profiler.hpp
+++ b/src/nnfusion/engine/pass/graph/blockfusion/blockfusion_profiler.hpp
@@ -25,8 +25,8 @@ public:
     blockfusion::ProfilingResult get_profiling_result();
 
 private:
-    blockfusion::ProfilingResult
-        get_codegen_profiling_result(BlockFusionCudaCodegen::Pointer codegen_context);
+    bool get_codegen_profiling_result(BlockFusionCudaCodegen::Pointer codegen_context,
+                                      blockfusion::ProfilingResult& codegen_profiling);
 
 private:
     BlockParallelDevice::Pointer block_parallel_device;

--- a/src/nnfusion/engine/pass/graph/blockfusion/common.hpp
+++ b/src/nnfusion/engine/pass/graph/blockfusion/common.hpp
@@ -96,6 +96,8 @@ namespace nnfusion
             }
         };
 
+        using ProfilingResult_p = std::shared_ptr<ProfilingResult>;
+
         /* ===== different types of block_executor_instructions begin ===== */
 
         class BlockExecutorInstructionExecuteBlock : public BlockExecutorInstruction

--- a/src/nnfusion/engine/pass/graph/blockfusion_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/blockfusion_pass.cpp
@@ -15,6 +15,10 @@ DEFINE_int32(
 DEFINE_bool(fblockfusion_interplay,
             true,
             "Interplay of intra- and inter- operator scheduling in BlockFusion");
+DEFINE_bool(fblockfusion_check_correctness,
+            false,
+            "Check the correctness of BlockFusion codegen and fallback to original execution when "
+            "failure detected");
 DECLARE_string(fproduct_name);
 DECLARE_string(fdefault_device);
 
@@ -29,13 +33,23 @@ bool BlockFusionPass::run_on_graph(std::shared_ptr<nnfusion::graph::Graph>& grap
     std::shared_ptr<BlockFusionOptimizer> optimizer;
     if (FLAGS_fblockfusion_level == 1)
     {
-        optimizer = std::make_shared<BlockFusionWavefrontOptimizer>(
-            graph, FLAGS_fdefault_device, FLAGS_fproduct_name, 1, FLAGS_fblockfusion_interplay);
+        optimizer =
+            std::make_shared<BlockFusionWavefrontOptimizer>(graph,
+                                                            FLAGS_fdefault_device,
+                                                            FLAGS_fproduct_name,
+                                                            1,
+                                                            FLAGS_fblockfusion_interplay,
+                                                            FLAGS_fblockfusion_check_correctness);
     }
     else if (FLAGS_fblockfusion_level == 2)
     {
-        optimizer = std::make_shared<BlockFusionWavefrontOptimizer>(
-            graph, FLAGS_fdefault_device, FLAGS_fproduct_name, 2, FLAGS_fblockfusion_interplay);
+        optimizer =
+            std::make_shared<BlockFusionWavefrontOptimizer>(graph,
+                                                            FLAGS_fdefault_device,
+                                                            FLAGS_fproduct_name,
+                                                            2,
+                                                            FLAGS_fblockfusion_interplay,
+                                                            FLAGS_fblockfusion_check_correctness);
     }
 
     if (optimizer->Optimize())


### PR DESCRIPTION
* implement BlockFusion correctness check with profiler #110 
* -fblockfusion_check_correctness=true can enable this check and blockfusion will fallback to original execution when failure detected
* this check may cost much time, so it is disabled by default