### PR TITLE
Fix DataBuffer

### DIFF
--- a/thirdparty/ngraph/src/nnfusion/core/operators/op_define/constant.hpp
+++ b/thirdparty/ngraph/src/nnfusion/core/operators/op_define/constant.hpp
@@ -109,8 +109,9 @@ namespace nnfusion
                     << nnfusion::shape_size(m_shape) << ").";
 
                 DataBuffer buf(element_type);
+                size_t shape_size = nnfusion::shape_size(m_shape);
 
-                buf.loadFromStrings(values);
+                buf.loadFromStrings(values, shape_size);
 
                 buf.dump(m_data);
             }


### PR DESCRIPTION
Fixed the problem that `DataBuffer` would not broadcast a vector of string with a size of 1, which caused a failure in unit-test reported in #164 .