### PR TITLE
fix cub cmakelists installation miss

### DIFF
--- a/src/tools/nnfusion/CMakeLists.txt
+++ b/src/tools/nnfusion/CMakeLists.txt
@@ -46,4 +46,6 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/nnfusion/templates DESTINATION b
 install(DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/nnfusion/eigen DESTINATION bin)
 install(DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/nnfusion/threadpool DESTINATION bin)
 install(DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/nnfusion/mlas DESTINATION bin)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/nnfusion/cub DESTINATION bin)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/src/tools/nnfusion/superscaler DESTINATION bin)
 install(DIRECTORY ${CMAKE_BINARY_DIR}/test/templates DESTINATION bin)


### PR DESCRIPTION
Added installation of <cub> to CMakeLists.txt, to fix the bug where NNFusion cannot find <cub> as a language unit