### PR TITLE
Disable dedicated pass for hlsl and fix bugs

### DIFF
--- a/models/pytorch2onnx/ort_run_frozen.py
+++ b/models/pytorch2onnx/ort_run_frozen.py
@@ -110,9 +110,10 @@ for warmup in range(args.warmup):
             # max_len = min(10, len(out_flat) - print_offset)
             # print(out_flat[print_offset:max_len + print_offset], "offset=", print_offset)
 
-print('>> Evalutating Benchmark ...')
-t_start = time.time()
-for step in range(args.iters):
-    ort_session.run(outputs_name, ort_inputs)
-t_end = time.time()
-print('>> Average time for each run: %.4f ms;' % ((t_end - t_start) * 1e3 / args.iters))
+if args.iters > 0:
+    print('>> Evalutating Benchmark ...')
+    t_start = time.time()
+    for step in range(args.iters):
+        ort_session.run(outputs_name, ort_inputs)
+    t_end = time.time()
+    print('>> Average time for each run: %.4f ms;' % ((t_end - t_start) * 1e3 / args.iters))

--- a/models/pytorch2onnx/ort_run_frozen.py
+++ b/models/pytorch2onnx/ort_run_frozen.py
@@ -8,11 +8,16 @@ import os
 import sys
 import time
 import onnx
+try:
+    from yaml import safe_load as load_func
+except ImportError:
+    from json import loads as load_func
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--file', type=str, default='./frozen_graph.onnx', help='The file name of the frozen graph.')
 parser.add_argument('--optimized_model_filepath', type=str, default='', help='The file name of the optimized frozen graph.')
 parser.add_argument('--graph_optimization_level', type=str, default='ORT_ENABLE_ALL', help='ONNX Runtime graph optimization level.')
+parser.add_argument('--symbolic_dims', type=load_func, default={}, help='The size of symbolic dimensions, provided by \'{"dim1_name": dim1, "dim2_name": dim2}\'')
 parser.add_argument('--warmup', type=int, default=5, help='The number of warmup iterations.')
 parser.add_argument('--iters', type=int, default=100, help='The number of execution iterations.')
 parser.add_argument('--provider', type=str, default='', help='The backend provider.')
@@ -73,6 +78,9 @@ elif args.graph_optimization_level == 'ORT_ENABLE_EXTENDED':
     sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
 if args.optimized_model_filepath != '':
     sess_options.optimized_model_filepath = args.optimized_model_filepath
+
+for k, v in args.symbolic_dims.items():
+    sess_options.add_free_dimension_override_by_name(k, int(v))
 
 ort_session = ort.InferenceSession(args.file, sess_options)
 

--- a/src/nnfusion/engine/device/cuda.cpp
+++ b/src/nnfusion/engine/device/cuda.cpp
@@ -16,7 +16,6 @@
 #include "nnfusion/engine/pass/graph/gnode_device_dispatcher.hpp"
 #include "nnfusion/engine/pass/graph/gradient_weight_mapping_pass.hpp"
 #include "nnfusion/engine/pass/graph/graph_serialization_pass.hpp"
-#include "nnfusion/engine/pass/graph/hlsl_required_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_fusion_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_profiling_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_selection.hpp"

--- a/src/nnfusion/engine/device/hlsl.cpp
+++ b/src/nnfusion/engine/device/hlsl.cpp
@@ -18,7 +18,6 @@
 #include "nnfusion/engine/pass/graph/gemm_fusion_pass.hpp"
 #include "nnfusion/engine/pass/graph/gnode_device_dispatcher.hpp"
 #include "nnfusion/engine/pass/graph/gradient_weight_mapping_pass.hpp"
-#include "nnfusion/engine/pass/graph/hlsl_required_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_fusion_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_profiling_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_selection.hpp"
@@ -49,7 +48,6 @@ HLSLEngine::HLSLEngine()
 {
     if (FLAGS_fhlsl_codegen_type == "csharp")
     {
-        g_passes->push_back(make_shared<HLSLRequiredPass>());
         g_passes->push_back(make_shared<CSEPass>());
         g_passes->push_back(make_shared<AutodiffPass>());
         g_passes->push_back(make_shared<GradientWeightMappingPass>());
@@ -89,7 +87,6 @@ HLSLEngine::HLSLEngine()
     }
     else if (FLAGS_fhlsl_codegen_type == "cpp")
     {
-        g_passes->push_back(make_shared<HLSLRequiredPass>());
         g_passes->push_back(make_shared<CSEPass>());
         g_passes->push_back(make_shared<AutodiffPass>());
         g_passes->push_back(make_shared<GradientWeightMappingPass>());

--- a/src/nnfusion/engine/pass/graph/CMakeLists.txt
+++ b/src/nnfusion/engine/pass/graph/CMakeLists.txt
@@ -28,7 +28,6 @@ set(SRC
     dot_transpose_pass.cpp
     reduce_fusion_pass.cpp
     superscaler_dataparallelism_pass.cpp
-    hlsl_required_pass.cpp
 )
 
 add_library(nnfusion_engine_pass_graph STATIC ${SRC})

--- a/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
@@ -92,10 +92,7 @@ namespace
 
 bool HLSLRequiredPass::run_on_graph(std::shared_ptr<nnfusion::graph::Graph>& graph)
 {
-    if (FLAGS_fdefault_device != "HLSL")
-    {
-        return true;
-    }
+    return true;
 
     map<element::Type, element::Type> type_mapping = {{element::i64, element::i32},
                                                       {element::u64, element::u32}};

--- a/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
@@ -92,7 +92,10 @@ namespace
 
 bool HLSLRequiredPass::run_on_graph(std::shared_ptr<nnfusion::graph::Graph>& graph)
 {
-    return true;
+    if (FLAGS_fdefault_device != "HLSL")
+    {
+        return true;
+    }
 
     map<element::Type, element::Type> type_mapping = {{element::i64, element::i32},
                                                       {element::u64, element::u32}};

--- a/src/nnfusion/engine/pass/graph/hlsl_required_pass.hpp
+++ b/src/nnfusion/engine/pass/graph/hlsl_required_pass.hpp
@@ -12,7 +12,7 @@ namespace nnfusion
         namespace graph
         {
             // This pass run some necessary change for HLSL codegen, including
-            // 1. Convert 64bit integer to 32bit
+            // 1. [Disabled, HLSL already support 64bit integer] Convert 64bit integer to 32bit
             class HLSLRequiredPass : public GraphPassBase
             {
             public:

--- a/src/nnfusion/engine/pass/graph/op_inplace_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/op_inplace_pass.cpp
@@ -13,6 +13,8 @@
 #include "nnfusion/core/operators/util/arithmetic_reduction.hpp"
 #include "nnfusion/core/operators/util/elementwise_arithmetic.hpp"
 
+DECLARE_bool(fantares_mode);
+
 using namespace nnfusion::graph;
 using namespace nnfusion::op;
 using namespace nnfusion::pass::graph;
@@ -89,8 +91,9 @@ bool OpInplacePass::run_on_graph(std::shared_ptr<Graph>& graph)
             AddInplace(op, 0, 2, true);
         }
 
-        else if (nnfusion::op::get_annotation(nnfusion::op::get_translation(node))
-                     .find("|memcpy|") != string::npos)
+        else if (FLAGS_fantares_mode &&
+                 nnfusion::op::get_annotation(nnfusion::op::get_translation(node))
+                         .find("|memcpy|") != string::npos)
         {
             auto op = node->get_op_ptr();
             AddInplace(op, 0, 0, false);

--- a/src/nnfusion/engine/pass/graph/runtime_const_folding_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/runtime_const_folding_pass.cpp
@@ -59,7 +59,7 @@ int RuntimeConstantFoldingPass::runtime_const_folding_iterate_once(
                            << ", Op Type = " << it->get_op_type();
 
         bool const_infer_success = false;
-        std::vector<std::vector<char>> raw_inputs, raw_outputs;
+        std::vector<std::vector<char>> raw_inputs(it->get_input_size()), raw_outputs;
 
         // Prepare constant inputs from upstream_nodes
         std::set<std::shared_ptr<GNode>> upstream_nodes;
@@ -83,10 +83,9 @@ int RuntimeConstantFoldingPass::runtime_const_folding_iterate_once(
             NNFUSION_LOG(INFO) << "  With Constant Input Node: " << p_const->get_name()
                                << ", Memory Length = " << length;
 
-            std::vector<char> raw_input(length);
-            memcpy(raw_input.data(), ptr, length);
-            raw_inputs.emplace_back(std::move(raw_input));
-            NNFUSION_CHECK(raw_input.size() == 0);
+            size_t input_index = input->get_dst_input();
+            raw_inputs[input_index].resize(length);
+            memcpy(raw_inputs[input_index].data(), ptr, length);
         }
 
         // Prepare runtime backend

--- a/src/nnfusion/frontend/onnx_import/onnx.cpp
+++ b/src/nnfusion/frontend/onnx_import/onnx.cpp
@@ -51,7 +51,44 @@ namespace nnfusion
             load_onnx_model(const std::string& path,
                             const std::unordered_map<std::string, size_t>& dim_params)
         {
-            std::ifstream ifs{path, std::ios::in | std::ios::binary};
+            NNFUSION_LOG(INFO) << "Optimizing ONNX Graph with External Tool "
+                                  "(models/pytorch2onnx/ort_run_frozen.py)";
+            string optimized_filename = string(tmpnam(nullptr));
+            string m_path = path;
+            string script_path =
+                nnfusion::codegen::get_file_from_templates("onnx/ort_run_frozen.py");
+            string cmd = "python3 " + script_path +
+                         " --graph_optimization_level ORT_ENABLE_BASIC "
+                         "--warmup 1 --iters 0 --provider CPUExecutionProvider --file " +
+                         path + " --optimized_model_filepath " + optimized_filename;
+            if (dim_params.size() > 0)
+            {
+                string dim_params_str = " --symbolic_dims \'{";
+                for (auto& it : dim_params)
+                {
+                    if (dim_params_str != " --symbolic_dims \'{")
+                    {
+                        dim_params_str += ", ";
+                    }
+                    dim_params_str += "\"" + it.first + "\": " + to_string(it.second);
+                }
+                dim_params_str += "}\'";
+                cmd += dim_params_str;
+            }
+            int sys_ret = system(cmd.c_str());
+            std::ifstream opt_fin(optimized_filename.c_str());
+            if (sys_ret == 0 && opt_fin.is_open())
+            {
+                m_path = optimized_filename;
+            }
+            else
+            {
+                NNFUSION_LOG(NNFUSION_WARNING)
+                    << "Failed to optimize ONNX Graph with external tool, please "
+                       "check error messages reported by the tool, fallback";
+            }
+
+            std::ifstream ifs{m_path, std::ios::in | std::ios::binary};
             NNFUSION_CHECK(ifs.is_open()) << "failure opening file:" + path;
             string model_dir = "";
             auto pos = path.rfind("/");
@@ -59,7 +96,15 @@ namespace nnfusion
             {
                 model_dir = path.substr(0, pos);
             }
-            return load_onnx_model(ifs, model_dir, dim_params);
+
+            auto graph = load_onnx_model(ifs, model_dir, dim_params);
+
+            if (opt_fin.is_open())
+            {
+                remove(optimized_filename.c_str());
+            }
+
+            return graph;
         }
     } // namespace frontend
 } // namespace nnfusion

--- a/src/nnfusion/frontend/onnx_import/op/where.cpp
+++ b/src/nnfusion/frontend/onnx_import/op/where.cpp
@@ -42,7 +42,7 @@ namespace nnfusion
                     auto node_name = node_proto.output(0);
                     nnfusion::op::OpConfig::any op_config;
 
-                    auto where_op = std::make_shared<op::GenericOp>(node_name, "Where", op_config);
+                    auto where_op = std::make_shared<op::GenericOp>(node_name, "Select", op_config);
                     auto where_gnode =
                         m_graph->add_node_and_edge(where_op, {cond_gnode, x_gnode, y_gnode});
 

--- a/src/nnfusion/frontend/onnx_import/util/graph_convert.cpp
+++ b/src/nnfusion/frontend/onnx_import/util/graph_convert.cpp
@@ -494,6 +494,20 @@ namespace nnfusion
                     m_graph_outputs.emplace_back(generic_gnode);
                 }
 
+                // Sort nGraph output nodes in the order of ONNX output nodes
+                std::vector<std::string> output_names;
+                for (const auto& output : onnx_graph_proto->output())
+                {
+                    output_names.push_back(output.name());
+                }
+                sort(m_graph_outputs.begin(),
+                     m_graph_outputs.end(),
+                     [&output_names](const std::shared_ptr<nnfusion::graph::GNode>& a,
+                                     const std::shared_ptr<nnfusion::graph::GNode>& b) {
+                         return std::find(output_names.begin(), output_names.end(), a->get_name()) <
+                                std::find(output_names.begin(), output_names.end(), b->get_name());
+                     });
+
                 m_graph->set_default_parameters();
                 m_graph->set_outputs(m_graph_outputs);
 

--- a/src/tools/nnfusion/CMakeLists.txt
+++ b/src/tools/nnfusion/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(nnfusion nnfusion_backend nnfusion_engine_pass_graph nnfus
 add_custom_command(
     TARGET nnfusion
     POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/tools/nnfusion/templates ${CMAKE_BINARY_DIR}/src/tools/nnfusion/templates
+    POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/models/pytorch2onnx/ort_run_frozen.py ${CMAKE_BINARY_DIR}/src/tools/nnfusion/templates/onnx/ort_run_frozen.py
     POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/thirdparty/eigen ${CMAKE_BINARY_DIR}/src/tools/nnfusion/eigen
     POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/thirdparty/threadpool ${CMAKE_BINARY_DIR}/src/tools/nnfusion/threadpool
     POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/thirdparty/mlas ${CMAKE_BINARY_DIR}/src/tools/nnfusion/mlas

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
@@ -170,6 +170,14 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
+
+    static std::string dos2unix(const string& input)
+    {
+        std::string res = input;
+        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+        res.erase(end_pos, res.end());
+        return res;
+    }
 }
 
 
@@ -236,6 +244,10 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -379,6 +391,10 @@ void* dxModuleLoad(const char* module_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
         module_src = source.c_str();
     }
 

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
@@ -170,14 +170,6 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
-
-    static std::string dos2unix(const string& input)
-    {
-        std::string res = input;
-        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
-        res.erase(end_pos, res.end());
-        return res;
-    }
 }
 
 
@@ -244,10 +236,6 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
-        if (source.find('\r') != std::string::npos)
-        {
-            source = dos2unix(source);
-        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -393,7 +381,10 @@ void* dxModuleLoad(const char* module_src)
         source = std::move(_);
         if (source.find('\r') != std::string::npos)
         {
-            source = dos2unix(source);
+            std::string res = source;
+            std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+            res.erase(end_pos, res.end());
+            source = std::move(res);
         }
         module_src = source.c_str();
     }

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12Util.h
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12Util.h
@@ -48,7 +48,7 @@ using namespace std;
 using namespace Microsoft::WRL;
 
 
-#define IFE(x)  ((FAILED(x)) ? (printf("Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
+#define IFE(x)  ((FAILED(x)) ? (printf((x) == E_OUTOFMEMORY ? "Error-line: (%s) %d\n\nDX out of memory": "Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
 
 namespace {
 

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
@@ -170,6 +170,14 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
+
+    static std::string dos2unix(const string& input)
+    {
+        std::string res = input;
+        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+        res.erase(end_pos, res.end());
+        return res;
+    }
 }
 
 
@@ -236,6 +244,10 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -379,6 +391,10 @@ void* dxModuleLoad(const char* module_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
         module_src = source.c_str();
     }
 

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
@@ -170,14 +170,6 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
-
-    static std::string dos2unix(const string& input)
-    {
-        std::string res = input;
-        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
-        res.erase(end_pos, res.end());
-        return res;
-    }
 }
 
 
@@ -244,10 +236,6 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
-        if (source.find('\r') != std::string::npos)
-        {
-            source = dos2unix(source);
-        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -393,7 +381,10 @@ void* dxModuleLoad(const char* module_src)
         source = std::move(_);
         if (source.find('\r') != std::string::npos)
         {
-            source = dos2unix(source);
+            std::string res = source;
+            std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+            res.erase(end_pos, res.end());
+            source = std::move(res);
         }
         module_src = source.c_str();
     }

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12Util.h
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12Util.h
@@ -48,7 +48,7 @@ using namespace std;
 using namespace Microsoft::WRL;
 
 
-#define IFE(x)  ((FAILED(x)) ? (printf("Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
+#define IFE(x)  ((FAILED(x)) ? (printf((x) == E_OUTOFMEMORY ? "Error-line: (%s) %d\n\nDX out of memory": "Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
 
 namespace {
 


### PR DESCRIPTION
1. 64bit integer is already supported in cs_6_0, so we disabled the conversion from 64 to 32bit integer
2. Fix onnx converter for `Where`
3. Feed inputs in order when runtime constant folding, fix #296 
4. Support load hlsl in windows-style line endings