### PR TITLE
Disable dedicated pass for hlsl and enhance antares wrapper

### DIFF
--- a/src/nnfusion/engine/device/cuda.cpp
+++ b/src/nnfusion/engine/device/cuda.cpp
@@ -16,7 +16,6 @@
 #include "nnfusion/engine/pass/graph/gnode_device_dispatcher.hpp"
 #include "nnfusion/engine/pass/graph/gradient_weight_mapping_pass.hpp"
 #include "nnfusion/engine/pass/graph/graph_serialization_pass.hpp"
-#include "nnfusion/engine/pass/graph/hlsl_required_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_fusion_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_profiling_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_selection.hpp"

--- a/src/nnfusion/engine/device/hlsl.cpp
+++ b/src/nnfusion/engine/device/hlsl.cpp
@@ -18,7 +18,6 @@
 #include "nnfusion/engine/pass/graph/gemm_fusion_pass.hpp"
 #include "nnfusion/engine/pass/graph/gnode_device_dispatcher.hpp"
 #include "nnfusion/engine/pass/graph/gradient_weight_mapping_pass.hpp"
-#include "nnfusion/engine/pass/graph/hlsl_required_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_fusion_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_profiling_pass.hpp"
 #include "nnfusion/engine/pass/graph/kernel_selection.hpp"
@@ -49,7 +48,6 @@ HLSLEngine::HLSLEngine()
 {
     if (FLAGS_fhlsl_codegen_type == "csharp")
     {
-        g_passes->push_back(make_shared<HLSLRequiredPass>());
         g_passes->push_back(make_shared<CSEPass>());
         g_passes->push_back(make_shared<AutodiffPass>());
         g_passes->push_back(make_shared<GradientWeightMappingPass>());
@@ -89,7 +87,6 @@ HLSLEngine::HLSLEngine()
     }
     else if (FLAGS_fhlsl_codegen_type == "cpp")
     {
-        g_passes->push_back(make_shared<HLSLRequiredPass>());
         g_passes->push_back(make_shared<CSEPass>());
         g_passes->push_back(make_shared<AutodiffPass>());
         g_passes->push_back(make_shared<GradientWeightMappingPass>());

--- a/src/nnfusion/engine/pass/graph/CMakeLists.txt
+++ b/src/nnfusion/engine/pass/graph/CMakeLists.txt
@@ -28,7 +28,6 @@ set(SRC
     dot_transpose_pass.cpp
     reduce_fusion_pass.cpp
     superscaler_dataparallelism_pass.cpp
-    hlsl_required_pass.cpp
 )
 
 add_library(nnfusion_engine_pass_graph STATIC ${SRC})

--- a/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
@@ -92,10 +92,7 @@ namespace
 
 bool HLSLRequiredPass::run_on_graph(std::shared_ptr<nnfusion::graph::Graph>& graph)
 {
-    if (FLAGS_fdefault_device != "HLSL")
-    {
-        return true;
-    }
+    return true;
 
     map<element::Type, element::Type> type_mapping = {{element::i64, element::i32},
                                                       {element::u64, element::u32}};

--- a/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/hlsl_required_pass.cpp
@@ -92,7 +92,10 @@ namespace
 
 bool HLSLRequiredPass::run_on_graph(std::shared_ptr<nnfusion::graph::Graph>& graph)
 {
-    return true;
+    if (FLAGS_fdefault_device != "HLSL")
+    {
+        return true;
+    }
 
     map<element::Type, element::Type> type_mapping = {{element::i64, element::i32},
                                                       {element::u64, element::u32}};

--- a/src/nnfusion/engine/pass/graph/hlsl_required_pass.hpp
+++ b/src/nnfusion/engine/pass/graph/hlsl_required_pass.hpp
@@ -12,7 +12,7 @@ namespace nnfusion
         namespace graph
         {
             // This pass run some necessary change for HLSL codegen, including
-            // 1. Convert 64bit integer to 32bit
+            // 1. [Disabled, HLSL already support 64bit integer] Convert 64bit integer to 32bit
             class HLSLRequiredPass : public GraphPassBase
             {
             public:

--- a/src/nnfusion/engine/pass/graph/runtime_const_folding_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/runtime_const_folding_pass.cpp
@@ -59,7 +59,7 @@ int RuntimeConstantFoldingPass::runtime_const_folding_iterate_once(
                            << ", Op Type = " << it->get_op_type();
 
         bool const_infer_success = false;
-        std::vector<std::vector<char>> raw_inputs, raw_outputs;
+        std::vector<std::vector<char>> raw_inputs(it->get_input_size()), raw_outputs;
 
         // Prepare constant inputs from upstream_nodes
         std::set<std::shared_ptr<GNode>> upstream_nodes;
@@ -83,10 +83,9 @@ int RuntimeConstantFoldingPass::runtime_const_folding_iterate_once(
             NNFUSION_LOG(INFO) << "  With Constant Input Node: " << p_const->get_name()
                                << ", Memory Length = " << length;
 
-            std::vector<char> raw_input(length);
-            memcpy(raw_input.data(), ptr, length);
-            raw_inputs.emplace_back(std::move(raw_input));
-            NNFUSION_CHECK(raw_input.size() == 0);
+            size_t input_index = input->get_dst_input();
+            raw_inputs[input_index].resize(length);
+            memcpy(raw_inputs[input_index].data(), ptr, length);
         }
 
         // Prepare runtime backend

--- a/src/nnfusion/frontend/onnx_import/op/where.cpp
+++ b/src/nnfusion/frontend/onnx_import/op/where.cpp
@@ -42,7 +42,7 @@ namespace nnfusion
                     auto node_name = node_proto.output(0);
                     nnfusion::op::OpConfig::any op_config;
 
-                    auto where_op = std::make_shared<op::GenericOp>(node_name, "Where", op_config);
+                    auto where_op = std::make_shared<op::GenericOp>(node_name, "Select", op_config);
                     auto where_gnode =
                         m_graph->add_node_and_edge(where_op, {cond_gnode, x_gnode, y_gnode});
 

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
@@ -170,6 +170,14 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
+
+    static std::string dos2unix(const string& input)
+    {
+        std::string res = input;
+        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+        res.erase(end_pos, res.end());
+        return res;
+    }
 }
 
 
@@ -236,6 +244,10 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -379,6 +391,10 @@ void* dxModuleLoad(const char* module_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
         module_src = source.c_str();
     }
 

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12APIWrapper.cpp
@@ -170,14 +170,6 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
-
-    static std::string dos2unix(const string& input)
-    {
-        std::string res = input;
-        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
-        res.erase(end_pos, res.end());
-        return res;
-    }
 }
 
 
@@ -244,10 +236,6 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
-        if (source.find('\r') != std::string::npos)
-        {
-            source = dos2unix(source);
-        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -393,7 +381,10 @@ void* dxModuleLoad(const char* module_src)
         source = std::move(_);
         if (source.find('\r') != std::string::npos)
         {
-            source = dos2unix(source);
+            std::string res = source;
+            std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+            res.erase(end_pos, res.end());
+            source = std::move(res);
         }
         module_src = source.c_str();
     }

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12Util.h
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DWinNN/runtime/D3D12Util.h
@@ -48,7 +48,7 @@ using namespace std;
 using namespace Microsoft::WRL;
 
 
-#define IFE(x)  ((FAILED(x)) ? (printf("Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
+#define IFE(x)  ((FAILED(x)) ? (printf((x) == E_OUTOFMEMORY ? "Error-line: (%s) %d\n\nDX out of memory": "Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
 
 namespace {
 

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
@@ -170,6 +170,14 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
+
+    static std::string dos2unix(const string& input)
+    {
+        std::string res = input;
+        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+        res.erase(end_pos, res.end());
+        return res;
+    }
 }
 
 
@@ -236,6 +244,10 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -379,6 +391,10 @@ void* dxModuleLoad(const char* module_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
+        if (source.find('\r') != std::string::npos)
+        {
+            source = dos2unix(source);
+        }
         module_src = source.c_str();
     }
 

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12APIWrapper.cpp
@@ -170,14 +170,6 @@ namespace {
             return def;
         return source.substr(idx, tail - idx);
     }
-
-    static std::string dos2unix(const string& input)
-    {
-        std::string res = input;
-        std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
-        res.erase(end_pos, res.end());
-        return res;
-    }
 }
 
 
@@ -244,10 +236,6 @@ void* dxShaderLoad_v2(const char* shader_src)
             return nullptr;
         std::string _((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         source = std::move(_);
-        if (source.find('\r') != std::string::npos)
-        {
-            source = dos2unix(source);
-        }
     }
 
     dx_shader_t* handle = new dx_shader_t;
@@ -393,7 +381,10 @@ void* dxModuleLoad(const char* module_src)
         source = std::move(_);
         if (source.find('\r') != std::string::npos)
         {
-            source = dos2unix(source);
+            std::string res = source;
+            std::string::iterator end_pos = std::remove(res.begin(), res.end(), '\r');
+            res.erase(end_pos, res.end());
+            source = std::move(res);
         }
         module_src = source.c_str();
     }

--- a/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12Util.h
+++ b/src/tools/nnfusion/templates/dxcompute/Direct3DXBoxNN/runtime/D3D12Util.h
@@ -48,7 +48,7 @@ using namespace std;
 using namespace Microsoft::WRL;
 
 
-#define IFE(x)  ((FAILED(x)) ? (printf("Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
+#define IFE(x)  ((FAILED(x)) ? (printf((x) == E_OUTOFMEMORY ? "Error-line: (%s) %d\n\nDX out of memory": "Error-line: (%s) %d\n\nPossible Reason:\n\tWindows TDR might be triggered.\n\tTo avoid this, please download and apply https://github.com/microsoft/antares/releases/download/v0.1.0/antares_hlsl_tdr_v0.1.reg into Windows registry and reboot your system to take effect.\nIf this is not fixed, please report an issue to https://github.com/microsoft/antares/issues\n\n", __FILE__, __LINE__), abort(), 0): 1)
 
 namespace {
 


### PR DESCRIPTION
1. 64bit integer is already supported in cs_6_0, so we disabled the conversion from 64 to 32bit integer
2. Fix onnx converter for `Where`
3. Feed inputs in order when runtime constant folding, fix #296 
4. Support load hlsl in windows-style line endings
5. Tell DirectX OOM apart from other errors
