### PR TITLE
Attempt to fix graph visit order

### DIFF
--- a/src/nnfusion/core/graph/gedge.hpp
+++ b/src/nnfusion/core/graph/gedge.hpp
@@ -39,5 +39,21 @@ namespace nnfusion
             int m_src_output;
             int m_dst_input;
         };
+
+        struct EdgeComparatorSrcIndex
+        {
+            bool operator()(const std::shared_ptr<Edge> lhs, const std::shared_ptr<Edge> rhs) const
+            {
+                return lhs->get_src_output() < rhs->get_src_output();
+            }
+        };
+
+        struct EdgeComparatorDstIndex
+        {
+            bool operator()(const std::shared_ptr<Edge> lhs, const std::shared_ptr<Edge> rhs) const
+            {
+                return lhs->get_dst_input() < rhs->get_dst_input();
+            }
+        };
     }
 }

--- a/src/nnfusion/core/graph/graph.cpp
+++ b/src/nnfusion/core/graph/graph.cpp
@@ -183,7 +183,7 @@ GNodeVector Graph::get_nodes()
     return valid_nodes;
 }
 
-GNodeVector Graph::get_ordered_ops(bool include_control_deps)
+GNodeVector Graph::get_ordered_ops()
 {
     // todo: stored ops instead of calculate each time
     GNodeVector nodes;
@@ -191,7 +191,7 @@ GNodeVector Graph::get_ordered_ops(bool include_control_deps)
                get_outputs(),
                nullptr,
                [&](std::shared_ptr<GNode> node) { nodes.push_back(node); },
-               NodeComparatorName());
+               nullptr);
 
     return nodes;
 }
@@ -416,7 +416,7 @@ void Graph::set_temporary_pool_size(size_t size)
 bool Graph::serialize_to_file(const std::string& file_path)
 {
     nnfusion::serialize::GraphDef graphdef;
-    auto nnfusion_nodes = get_ordered_ops(true);
+    auto nnfusion_nodes = get_ordered_ops();
     for (auto& nnfusion_node : nnfusion_nodes)
     {
         NNFUSION_CHECK(

--- a/src/nnfusion/core/graph/graph.hpp
+++ b/src/nnfusion/core/graph/graph.hpp
@@ -72,7 +72,7 @@ namespace nnfusion
             // REQUIRES: 0 <= id < get_max_node_id().
 
             GNodeVector get_nodes();
-            GNodeVector get_ordered_ops(bool include_control_deps = true);
+            GNodeVector get_ordered_ops();
             GNodeVector get_bfs_ordered_ops();
 
             GNodeVector get_const_nodes();

--- a/src/nnfusion/core/graph/graph_util.cpp
+++ b/src/nnfusion/core/graph/graph_util.cpp
@@ -74,7 +74,10 @@ void nnfusion::graph::ReverseDFS(const Graph* graph,
         }
         else
         {
-            for (auto in_edge : node->get_in_edges())
+            auto in_edges = node->get_in_edges();
+            std::vector<std::shared_ptr<Edge>> in_edges_sorted(in_edges.begin(), in_edges.end());
+            std::sort(in_edges_sorted.begin(), in_edges_sorted.end(), EdgeComparatorDstIndex());
+            for (auto in_edge : in_edges)
             {
                 add_work(in_edge->get_src());
             }


### PR DESCRIPTION
1. Remove randomness when converting onnx to nnfusion graph, prefer to keep the order in onnx model file
2. Get_order_op() sorts ancestors by input index instead of ancestor name.