### PR TITLE
Fix correctness problems in GNN training

### DIFF
--- a/src/nnfusion/engine/pass/graph/autodiff/range.cpp
+++ b/src/nnfusion/engine/pass/graph/autodiff/range.cpp
@@ -1,0 +1,27 @@
+//*****************************************************************************
+// Copyright 2017-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include "backward_registry.hpp"
+
+REGISTER_BACKWARD_TRANSLATOR(Range).translator(
+    [](std::shared_ptr<GNode> forward_node,
+       const GNodeIndexVector& outputs_grad,
+       std::shared_ptr<nnfusion::graph::Graph> graph) -> GNodeIndexVector {
+        // Range no backprop
+        return GNodeIndexVector{pass::graph::autodiff::DiffEngine::EMPTY_GNODE_INDEX,
+                                pass::graph::autodiff::DiffEngine::EMPTY_GNODE_INDEX,
+                                pass::graph::autodiff::DiffEngine::EMPTY_GNODE_INDEX};
+    });

--- a/src/nnfusion/frontend/onnx_import/util/graph_convert.cpp
+++ b/src/nnfusion/frontend/onnx_import/util/graph_convert.cpp
@@ -352,8 +352,7 @@ namespace nnfusion
                     {
                         move_external_to_rawdata(tensor, model_dir);
                         if (FLAGS_ftraining_mode &&
-                            !(tensor.name().find_first_not_of("0123456789") == std::string::npos) &&
-                            (tensor.name().find("word_embeddings") == std::string::npos))
+                            !(tensor.name().find_first_not_of("0123456789") == std::string::npos))
                         {
                             element::Type type;
                             ONNXDataTypeToNNFusionElementType(


### PR DESCRIPTION
- [x] onnxruntime-based constant folding creates wrong folding results on nnfusion's training graph: it will fold parameters.
- [x] backward support for range op
- [x] need to import word_embeddings as parameters to train word_embeddings