### PR TITLE
Fix exit status is always zero

### DIFF
--- a/src/python/nnfusion/__main__.py
+++ b/src/python/nnfusion/__main__.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import site
+import subprocess
 import sys
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
@@ -17,8 +18,8 @@ def run_cli():
         logging.error("No nnfusion cli found: Try to reinstall nnfusion.")
         sys.exit(-1)
 
-    args = " ".join(sys.argv[1:])
-    os.system("%s %s" % (nnf_bin, args))
+    cmd = " ".join([nnf_bin] + sys.argv[1:])
+    return subprocess.call(cmd, shell=True)
 
 
 def welcome():
@@ -33,8 +34,8 @@ def welcome():
 
 def main():
     welcome()
-    run_cli()
+    return run_cli()
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
#363 
Add `sys.exit(main())` so that the console script entry-point in the pip-installable package  will have the same behavior as when run directly ([packaging-considerations](https://docs.python.org/3/library/__main__.html#packaging-considerations)). Additionally, the return value of `os.system` is system-dependent and may shift by 8 if the signal number is zero ([os.system](https://docs.python.org/3/library/os.html#os.system)). This may cause the exit status is still 0 (low byte = signal number = 0), and therefore, I replaced it with `subprocess.call`.

> Most systems require it to be in the range 0–127, and produce undefined results otherwise. ([sys.exit](https://docs.python.org/3/library/sys.html#sys.exit))

I'd love to hear your feedback.