### PR TITLE
Fix FP16 codegen for ONNXmodels

### DIFF
--- a/models/pytorch2onnx/ort_run_frozen.py
+++ b/models/pytorch2onnx/ort_run_frozen.py
@@ -82,7 +82,12 @@ if args.optimized_model_filepath != '':
 for k, v in args.symbolic_dims.items():
     sess_options.add_free_dimension_override_by_name(k, int(v))
 
-ort_session = ort.InferenceSession(args.file, sess_options, providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+if 'CUDAExecutionProvider' in ort.get_available_providers():
+    eps = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+else:
+    eps = ['CPUExecutionProvider']
+
+ort_session = ort.InferenceSession(args.file, sess_options, providers=eps)
 
 if args.provider != '':
     ort_session.set_providers([args.provider])

--- a/models/pytorch2onnx/ort_run_frozen.py
+++ b/models/pytorch2onnx/ort_run_frozen.py
@@ -82,7 +82,7 @@ if args.optimized_model_filepath != '':
 for k, v in args.symbolic_dims.items():
     sess_options.add_free_dimension_override_by_name(k, int(v))
 
-ort_session = ort.InferenceSession(args.file, sess_options)
+ort_session = ort.InferenceSession(args.file, sess_options, providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
 
 if args.provider != '':
     ort_session.set_providers([args.provider])

--- a/src/nnfusion/core/operators/op_define/constant.hpp
+++ b/src/nnfusion/core/operators/op_define/constant.hpp
@@ -50,12 +50,16 @@ namespace nnfusion
                 , m_data(nnfusion::aligned_alloc(
                       m_element_type.size(), nnfusion::shape_size(m_shape) * m_element_type.size()))
             {
+                size_t literal_num = values.size() * sizeof(T) / element_type.size();
+                // OP_VALIDATION(this,
+                //               values.size() == 1 || values.size() == nnfusion::shape_size(m_shape))
                 OP_VALIDATION(this,
-                              values.size() == 1 || values.size() == nnfusion::shape_size(m_shape))
+                              literal_num == 1 || literal_num == nnfusion::shape_size(m_shape))
                     << "Did not get the expected number of literals for a constant of shape "
                     << m_shape << " (got " << values.size() << ", expected "
                     << (nnfusion::shape_size(m_shape) == 1 ? "" : "1 or ")
-                    << nnfusion::shape_size(m_shape) << ").";
+                    << nnfusion::shape_size(m_shape) << ")."
+                    << element_type;
 
                 if (values.size() == 1)
                 {

--- a/src/nnfusion/core/operators/op_define/constant.hpp
+++ b/src/nnfusion/core/operators/op_define/constant.hpp
@@ -58,8 +58,7 @@ namespace nnfusion
                     << "Did not get the expected number of literals for a constant of shape "
                     << m_shape << " (got " << values.size() << ", expected "
                     << (nnfusion::shape_size(m_shape) == 1 ? "" : "1 or ")
-                    << nnfusion::shape_size(m_shape) << ")."
-                    << element_type;
+                    << nnfusion::shape_size(m_shape) << ")." << element_type;
 
                 if (values.size() == 1)
                 {

--- a/src/nnfusion/frontend/onnx_import/core/tensor.hpp
+++ b/src/nnfusion/frontend/onnx_import/core/tensor.hpp
@@ -71,8 +71,9 @@ namespace nnfusion
                     case onnx::TensorProto_DataType::TensorProto_DataType_BOOL:
                         return element::boolean;
                     case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT:
-                    case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
                         return element::f32;
+                    case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
+                        return element::f16;
                     case onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE:
                         return element::f64;
                     case onnx::TensorProto_DataType::TensorProto_DataType_INT8: return element::i8;

--- a/src/nnfusion/frontend/onnx_import/onnx.cpp
+++ b/src/nnfusion/frontend/onnx_import/onnx.cpp
@@ -59,7 +59,7 @@ namespace nnfusion
                 nnfusion::codegen::get_file_from_templates("onnx/ort_run_frozen.py");
             string cmd = "python3 " + script_path +
                          " --graph_optimization_level ORT_ENABLE_BASIC "
-                         "--warmup 1 --iters 0 --provider CPUExecutionProvider --file " +
+                         "--warmup 1 --iters 0 --file " +
                          path + " --optimized_model_filepath " + optimized_filename;
             if (dim_params.size() > 0)
             {

--- a/src/nnfusion/frontend/onnx_import/util/util.cpp
+++ b/src/nnfusion/frontend/onnx_import/util/util.cpp
@@ -37,8 +37,10 @@ namespace nnfusion
                     *nnfusion_et = element::boolean;
                     break;
                 case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT:
-                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
                     *nnfusion_et = element::f32;
+                    break;
+                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
+                    *nnfusion_et = element::f16;
                     break;
                 case onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE:
                     *nnfusion_et = element::f64;
@@ -91,8 +93,9 @@ namespace nnfusion
                 case onnx::TensorProto_DataType::TensorProto_DataType_BOOL:
                     return make_constant_op<bool>(element::boolean, shape, tensor);
                 case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT:
-                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
                     return make_constant_op<float>(element::f32, shape, tensor);
+                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
+                    return make_constant_op<float>(element::f16, shape, tensor);
                 case onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE:
                     return make_constant_op<double>(element::f64, shape, tensor);
                 case onnx::TensorProto_DataType::TensorProto_DataType_INT8:


### PR DESCRIPTION
Use CUDAExecutionProvider by default to optimize FP16 models, this can avoid unintentionaly cast all fp16 inputs/weights to fp32. 