### PR TITLE
Support JIT for class and class method + nnf config + 3-lvl-signature

### DIFF
--- a/docs/NNFusion-JIT.md
+++ b/docs/NNFusion-JIT.md
@@ -1,0 +1,117 @@
+# How to use NNFusion JIT
+
+NNFusion JIT is a JIT compiler for PyTorch using NNFusion CLI. It allows the user to JIT a function or a `torch.nn.Module` object using a decorator or a function wrapper. All NNFusion optimization such as kernel tuning can be applied using this interface.
+
+## nnfusion.jit
+
+`nnfusion.jit(obj=None, *, tune=None, tuning_steps=None, config=None)`
+
+Lazily trace an object and optimize using nnfusion compilation until the object is called. It can be used as a decorator or an explicit function wrapper. The inputs and outputs of the object should be `torch.Tensor` or a sequence of `torch.Tensor`.
+
+### Parameters
+
++ obj (function, `torch.nn.Module` instance / method / class):
+    +  Target object to be traced. When `obj` is an instance or a class, it is equivalent to tracing its `forward` function.
++ tune (Optional[bool]):
+    + Whether to tune kernel. By default it follows `config`. If set, it overwrites `config`.
++ tuning_steps (Optional[int]):
+    + Number of kernel tuning steps. By default it follows `config`. If set, it overwrites `config` and `tune`.
+            
++ config (Optional[dict, nnfusion.Config]):
+    + NNFusion compilation config. By default it will be set to default config `nnfusion.Config()`. Pass a `dict` to overwrite default config or directly pass an instance of `nnfusion.Config`.
+    + For example, `@nnfusion.jit(tune=True, config={'kernel_tuning_steps': 42})`
+    + For more flags information, please execute the command `nnfusion` in the terminal.
+
+
+### Use Cases Demo
+
+
+`nnfusion.jit` can be used as a function wrapper for standalone functions and `torch.nn.Module` instances/methods/classes.
+
+
+It can also be used as a decorator for standalone functions and `torch.nn.Module` methods/classes. 
+
+
+```python
+# Case 1: decorator for a standalone function
+@nnfusion.jit
+def foo(t1, t2):
+    return t1 + t2, t1 - t2
+
+
+# Case 2: decorator for a class method
+class Net(nn.Linear):
+    @nnfusion.jit
+    def foo(self, x):
+        return super().forward(x)
+
+    
+# Case 3: decorator for a class
+@nnfusion.jit
+class Net(nn.Linear):
+    def this_will_not_be_traced(self, x):
+        return super().forward(x)
+    def forward(self, x):
+        return super().forward(x)
+    
+
+# Case 4: function for a standalone function
+def foo(t1, t2):
+    return t1 + t2, t1 - t2
+jitted_foo = nnfusion.jit(foo)
+
+
+# Case 5: function for a torch.nn.Module class method
+class Net(nn.Linear):
+    def foo(self, x):
+        return super().forward(x)
+model = Net().eval()
+model.foo = nnfusion.jit(model.foo)
+
+
+# Case 6: function for a torch.nn.Module class 
+jitted_linear = nnfusion.jit(nn.Linear)
+model = jitted_linear().eval()
+
+
+# Case 7: function for a torch.nn.Module instance
+class Net(nn.Linear):
+    def forward(self, x):
+        return super().forward(x)
+model = Net().eval()
+jitted_model = nnfusion.jit(model)
+```
+
+It is allowed to pass optional keyword arguments:
+
+```python
+@nnfusion.jit(tune=True) 
+def foo(t1, t2):
+    return t1 + t2
+
+def bar(t):
+    return t + t, t * t
+jitted_bar = nnfusion.jit(bar, tuning_steps=2000)
+```
+
+### Compiled kernels caching strategies
+
+The compiled kernels are saved in `nnf-kernels/`. If a "match" kernel is found before the compilation, it will be directly reused. Here, "match" means having the same object signature (`__module__` and `__qualname__`), computational graph (ONNX model binary), and NNFusion compilation config (`config`).
+
+## nnfusion.Config
+
+`nnfusion.Config(*args, antares_mode=True, blockfusion_level=0, extern_result_memory=True, function_codegen=True, ir_based_fusion=False, kernel_fusion_level=0, kernel_tuning_steps=1000, **kwargs)`
+
+NNFusion compilation config. Can pass in any other NNFusion compiler flags (execute the command `nnfusion` in the terminal for more details) and unknown flags will be ignored. Use it as a `dict` with some default key-value pairs.
+
+### Use Cases Demo
+
+```python
+config = nnfusion.Config(function_codegen=False,
+                         new_flag=42)
+config = nnfusion.Config({'function_codegen': False,
+                          'new_flag': 42})
+config = nnfusion.Config()
+config['function_codegen'] = False
+config['new_flag'] = 42
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the NNFusion Documents!
    - [Compile-a-Tensorflow-model-with-NNFusion](Compile-a-Tensorflow-model-with-NNFusion.md)
    - [Compile-a-model-with-kernel-tuning-enabled](Compile-a-model-with-kernel-tuning-enabled.md)
    - [How to use NNFusion Python interface for inference/training](../src/python/example/README.md)
+   - [How to use NNFusion JIT](NNFusion-JIT.md)
 4. [Guide-for-Contributors](Guide-for-Contributors.md)
    - [Contribution-Guide](Contribution-Guide.md)
    - [Coding-Guide](Coding-Guide.md)

--- a/src/python/nnfusion/__init__.py
+++ b/src/python/nnfusion/__init__.py
@@ -5,3 +5,4 @@ __version__ = "0.3.0"
 __author__ = "Microsoft"
 
 from .jit import jit
+from .config import Config

--- a/src/python/nnfusion/config.py
+++ b/src/python/nnfusion/config.py
@@ -1,0 +1,30 @@
+class Config(dict):
+    def __init__(self,
+		 *args,
+            	 antares_mode=True,
+            	 blockfusion_level=0,
+            	 extern_result_memory=True,
+            	 function_codegen=True,
+            	 ir_based_fusion=False,
+            	 kernel_fusion_level=0,
+            	 kernel_tuning_steps=1000,
+		 **kwargs):
+
+        locals_ = locals()
+        super().__init__({
+            flag: locals_[flag]
+            for flag in self.__init__.__kwdefaults__
+        })
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _parse_flag_value(flag, value):
+        value = int(value) if isinstance(value, bool) else value
+        return f'-f{flag}={value}'
+
+    def to_flag(self):
+        return ' '.join([
+            self._parse_flag_value(flag, self[flag])
+            for flag in sorted(self.keys())
+        ])
+

--- a/src/python/nnfusion/config.py
+++ b/src/python/nnfusion/config.py
@@ -1,4 +1,7 @@
-class Config(dict):
+from collections.abc import MutableMapping
+
+
+class Config(MutableMapping):
     """NNFusion compilation flags"""
     def __init__(self,
                  *args,
@@ -12,11 +15,12 @@ class Config(dict):
                  **kwargs):
         """A `dict` with default values"""
         locals_ = locals()
-        super().__init__({
+
+        self._storage = {
             flag: locals_[flag]
             for flag in self.__init__.__kwdefaults__
-        })
-        super().__init__(*args, **kwargs)
+        }
+        self._storage.update(dict(*args, **kwargs))
 
     @staticmethod
     def _parse_flag_value(flag, value):
@@ -25,6 +29,21 @@ class Config(dict):
 
     def to_flag(self):
         return ' '.join([
-            self._parse_flag_value(flag, self[flag])
-            for flag in sorted(self.keys())
+            self._parse_flag_value(flag, value)
+            for flag, value in sorted(self._storage.items())
         ])
+
+    def __iter__(self):
+        return iter(self._storage)
+
+    def __len__(self):
+        return len(self._storage)
+
+    def __getitem__(self, key):
+        return self._storage[key]
+
+    def __setitem__(self, key, value):
+        self._storage[key] = value
+
+    def __delitem__(self, key):
+        del self._storage[key]

--- a/src/python/nnfusion/config.py
+++ b/src/python/nnfusion/config.py
@@ -1,14 +1,14 @@
 class Config(dict):
     def __init__(self,
-		 *args,
-            	 antares_mode=True,
-            	 blockfusion_level=0,
-            	 extern_result_memory=True,
-            	 function_codegen=True,
-            	 ir_based_fusion=False,
-            	 kernel_fusion_level=0,
-            	 kernel_tuning_steps=1000,
-		 **kwargs):
+                 *args,
+                 antares_mode=True,
+                 blockfusion_level=0,
+                 extern_result_memory=True,
+                 function_codegen=True,
+                 ir_based_fusion=False,
+                 kernel_fusion_level=0,
+                 kernel_tuning_steps=1000,
+                 **kwargs):
 
         locals_ = locals()
         super().__init__({
@@ -27,4 +27,3 @@ class Config(dict):
             self._parse_flag_value(flag, self[flag])
             for flag in sorted(self.keys())
         ])
-

--- a/src/python/nnfusion/config.py
+++ b/src/python/nnfusion/config.py
@@ -2,7 +2,12 @@ from collections.abc import MutableMapping
 
 
 class Config(MutableMapping):
-    """NNFusion compilation flags"""
+    """
+    NNFusion compilation config. Can pass in any other NNFusion compiler flags
+    (execute the command `nnfusion` in the terminal for more details) and
+    unknown flags will be ignored.
+    Use it as a `dict` with some default key-value pairs.
+    """
     def __init__(self,
                  *args,
                  antares_mode=True,
@@ -13,7 +18,6 @@ class Config(MutableMapping):
                  kernel_fusion_level=0,
                  kernel_tuning_steps=1000,
                  **kwargs):
-        """A `dict` with default values"""
         locals_ = locals()
 
         self._storage = {

--- a/src/python/nnfusion/config.py
+++ b/src/python/nnfusion/config.py
@@ -1,4 +1,5 @@
 class Config(dict):
+    """NNFusion compilation flags"""
     def __init__(self,
                  *args,
                  antares_mode=True,
@@ -9,7 +10,7 @@ class Config(dict):
                  kernel_fusion_level=0,
                  kernel_tuning_steps=1000,
                  **kwargs):
-
+        """A `dict` with default values"""
         locals_ = locals()
         super().__init__({
             flag: locals_[flag]

--- a/src/python/nnfusion/executor.py
+++ b/src/python/nnfusion/executor.py
@@ -87,6 +87,8 @@ class Executor(object):
         Parameters:
             nnf_rt_dir: A full string path to nnfusion runtime,
                 it's usually like "codegen_root/nnfusion_rt/cuda_codegen".
+            device: A device type (`torch.device`) that is used for workspace
+                memory reservation (if needed) by nnfusion runtime.
         """
         nnf_rt_dir = os.path.abspath(nnf_rt_dir)
         self.libnnf_path = find_nnf_rt(nnf_rt_dir)

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -33,20 +33,23 @@ def get_nrt_forward(obj, signature, config, outputs, *inputs,
     if output_is_tensor:
         outputs = [outputs]
 
-    nnf = NNFusionRT(obj, config, signature)
+    nnf = NNFusionRT(obj, config, signature, is_method=is_method)
     nnf.compile(inputs, outputs)
 
     # TODO free outputs and only save desc?
 
     def forward(*inputs):
-        if is_method:
-            _, *inputs = inputs
         results = [
             torch.empty_like(output)
             for output in outputs
         ]
-        inputs = list(inputs)
-        nnf.run(inputs, results)
+
+        if is_method:
+            obj, *inputs = inputs
+            nnf.run(obj, inputs, results)
+        else:
+            inputs = list(inputs)
+            nnf.run(inputs, results)
 
         if output_is_tensor:
             return results[0]

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -33,7 +33,7 @@ def get_nrt_forward(obj, signature, config, outputs, *inputs,
     if output_is_tensor:
         outputs = [outputs]
 
-    nnf = NNFusionRT(obj, config, signature, is_method=is_method)
+    nnf = NNFusionRT(obj, config, signature)
     nnf.compile(inputs, outputs)
 
     # TODO free outputs and only save desc?
@@ -46,7 +46,7 @@ def get_nrt_forward(obj, signature, config, outputs, *inputs,
 
         if is_method:
             obj, *inputs = inputs
-            nnf.run(obj, inputs, results)
+            nnf.run_method(obj, inputs, results)
         else:
             inputs = list(inputs)
             nnf.run(inputs, results)

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -109,8 +109,8 @@ def jit(_obj=None, signature=None, **kwargs):
             or is_method_of_instance(obj, torch.nn.Module)
         ):
             raise RuntimeError(
-                "Accept function or torch.nn.Module or class method of "
-                f"torch.nn.Module but found {obj}"
+                "Accept function or torch.nn.Module instance/method/class "
+                f"but found {obj}"
             )
 
         if is_subclass_of_cls(obj, torch.nn.Module):
@@ -119,7 +119,9 @@ def jit(_obj=None, signature=None, **kwargs):
                 Dummy class using dynamic inheritance to override forward
                 function and keep its signature.
                 """
-                @jit(signature='.'.join([get_signature(obj), 'forward']),
+                @jit(signature=('.'.join([get_signature(obj), 'forward'])
+                                if signature is None else
+                                signature),
                      **kwargs)
                 def forward(self, *args, **kwargs):
                     return super().forward(*args, **kwargs)

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -1,27 +1,41 @@
+import copy
 import functools
+from inspect import isfunction, ismethod
 
 import torch
 
-from .jit_utils import TorchModule
+from .jit_utils import TorchModule, get_signature
 from .runtime import NNFusionRT
 
 
-def nrt_forward(obj, *inputs, **kwargs):
+def is_method_of_instance(obj, cls):
+    return ismethod(obj) and isinstance(obj.__self__, cls)
+
+
+def get_nrt_forward(obj, signature, outputs, *inputs,
+                    is_method=False, **kwargs):
+    """
+    Return a wrapped forward function that using nnf as runtime
+    """
+
     if not isinstance(obj, torch.nn.Module):
-        return nrt_forward(TorchModule(obj), *inputs, **kwargs)
+        raise AssertionError(
+            "Internal bug, please report to "
+            "https://github.com/microsoft/nnfusion"
+        )
 
-    outputs = obj(*inputs)
     output_is_tensor = isinstance(outputs, torch.Tensor)
-
     if output_is_tensor:
         outputs = [outputs]
 
-    nnf = NNFusionRT(obj, **kwargs)
+    nnf = NNFusionRT(obj, signature, **kwargs)
     nnf.compile(inputs, outputs)
 
     # TODO free outputs and only save desc?
 
     def forward(*inputs):
+        if is_method:
+            _, *inputs = inputs
         results = [
             torch.empty_like(output)
             for output in outputs
@@ -32,20 +46,82 @@ def nrt_forward(obj, *inputs, **kwargs):
         if output_is_tensor:
             return results[0]
         return results
-
     return forward
 
 
-def jit(_func=None, **kwargs):
-    def decorator_jit(func):
-        @functools.wraps(func)
+def nrt_forward(obj, *inputs, is_method=False, **kwargs):
+
+    signature = get_signature(obj)
+
+    if hasattr(obj, '_orig_forward'):
+        # shallow copy is needed to avoid recursion
+        # call instance forward -> call nnf_forward -> call instance forward
+        obj_ = copy.copy(obj)
+        obj_.forward = obj._orig_forward
+        obj = obj_
+
+    outputs = obj(*inputs)
+
+    def jit_class_method_using_decorator():
+        """
+        Check if obj is a class method with @nnfusion.jit decorator.
+        The cases of decorating class method with the @ symbol or applying it
+        as function are different.
+        """
+        return isinstance(inputs[0], torch.nn.Module)
+
+    if jit_class_method_using_decorator():
+        self, *inputs = inputs
+
+        # shallow copy is needed to avoid recursion when using jit as decorator:
+        # export onnx -> call forward to trace -> call nnf jit func -> export onnx
+        self_ = copy.copy(self)
+
+        def forward(*args):
+            if forward.first_call:
+                forward.first_call = False
+                return obj(self, *args)
+            # handle the case that jit target function will call `forward`
+            return self.forward(*args)
+        forward.first_call = True
+        self_.forward = forward
+
+        return get_nrt_forward(self_, signature, outputs,
+                               *inputs, is_method=True, **kwargs)
+
+    if isfunction(obj) or is_method_of_instance(obj, torch.nn.Module):
+        return get_nrt_forward(TorchModule(obj), signature, outputs,
+                               *inputs, **kwargs)
+    return get_nrt_forward(obj, signature, outputs, *inputs, **kwargs)
+
+
+def jit(_obj=None, **kwargs):
+    def decorator_jit(obj):
+
+        if not (
+            isfunction(obj)
+            or isinstance(obj, torch.nn.Module)
+            or is_method_of_instance(obj, torch.nn.Module)
+        ):
+            raise RuntimeError(
+                "Accept function or torch.nn.Module or class method of "
+                f"torch.nn.Module but found {obj}"
+            )
+
+        @functools.wraps(obj)
         def wrapper(*args):  # TODO support kwargs?
             if wrapper.forward is None:
-                wrapper.forward = nrt_forward(func, *args, **kwargs)
+                wrapper.forward = nrt_forward(obj, *args, **kwargs)
             return wrapper.forward(*args)
         wrapper.forward = None
+
+        # If jit an instance, return itself instead of only a function
+        if isinstance(obj, torch.nn.Module):
+            obj._orig_forward = obj.forward
+            obj.forward = wrapper
+            return obj
         return wrapper
 
-    if _func is None:
+    if _obj is None:
         return decorator_jit
-    return decorator_jit(_func)
+    return decorator_jit(_obj)

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -33,7 +33,6 @@ def get_nrt_forward(obj, signature, config, outputs, *inputs,
     if output_is_tensor:
         outputs = [outputs]
 
-    # TODO nnf = NNFusionRT(obj, signature, **kwargs)
     nnf = NNFusionRT(obj, config, signature)
     nnf.compile(inputs, outputs)
 

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -168,11 +168,20 @@ def jit_class(obj, config):
 def jit(obj=None, *, tune=None, tuning_steps=None, config=None, _signature=None):
     """
     Parameters:
-        obj:
-        tune:
-        tuning_steps:
-        config:
-        _signature:
+        obj (function, `torch.nn.Module` instance/method/class):
+            The target object to be traced. When `obj` is an instance or a
+            class, it is equivalent to trace its `forward` function.
+        tune (Optional[bool]):
+            Whether to tune kernel.
+            By default it follows `config`, overwrite `config` if set.
+        tuning_steps (Optional[int]):
+            Number of kernel tuning steps.
+            By default it follows `config`, overwrite `config` if set.
+        config (Optional[dict, nnfusion.Config]):
+            NNFusion compilation config.
+            By default it will be set to `nnfusion.Config()`.
+            Pass a `dict` to overwrite default config or directly pass
+            in an instance of `nnfusion.Config`.
     """
 
     config = parse_config(tune, tuning_steps, config)

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -109,14 +109,14 @@ def parse_config(tune, tuning_steps, config):
     if not type(config) is Config:
         raise TypeError(
             "Expected optional 'config' argument of type dict or "
-            "nnfusion.Config but found {config}"
+            f"nnfusion.Config but found {config}"
         )
 
     if tuning_steps is not None:
         if not isinstance(tuning_steps, int):
             raise TypeError(
                 "Expected optional 'tuning_steps' argument of type int "
-                "but found {tuning_steps}"
+                f"but found {tuning_steps}"
             )
         if tune is False:
             raise ValueError(
@@ -131,7 +131,7 @@ def parse_config(tune, tuning_steps, config):
         if not isinstance(tune, bool):
             raise TypeError(
                 "Expected optional 'tune' argument of type bool "
-                "but found {tune}"
+                f"but found {tune}"
             )
         config['antares_mode'] = tune
 
@@ -171,16 +171,16 @@ def jit(obj=None, *, tune=None, tuning_steps=None, config=None, _signature=None)
             The target object to be traced. When `obj` is an instance or a
             class, it is equivalent to trace its `forward` function.
         tune (Optional[bool]):
-            Whether to tune kernel.
-            By default it follows `config`, overwrite `config` if set.
+            Whether to tune kernel. By default it follows `config`.
+            If set, it overwrites `config`.
         tuning_steps (Optional[int]):
-            Number of kernel tuning steps.
-            By default it follows `config`, overwrite `config` if set.
+            Number of kernel tuning steps. By default it follows `config`.
+            If set, it overwrites `config` and `tune`.
         config (Optional[dict, nnfusion.Config]):
             NNFusion compilation config.
             By default it will be set to `nnfusion.Config()`.
-            Pass a `dict` to overwrite default config or directly pass
-            in an instance of `nnfusion.Config`.
+            Pass a `dict` to overwrite default config or directly pass an
+            instance of `nnfusion.Config`.
     """
 
     config = parse_config(tune, tuning_steps, config)

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -181,6 +181,10 @@ def jit(obj=None, *, tune=None, tuning_steps=None, config=None, _signature=None)
             By default it will be set to `nnfusion.Config()`.
             Pass a `dict` to overwrite default config or directly pass an
             instance of `nnfusion.Config`.
+            For example, `@nnfusion.jit(tune=True,
+            config={'kernel_tuning_steps': 42})`
+            For more flags information, please execute the command `nnfusion`
+            in the terminal.
     """
 
     config = parse_config(tune, tuning_steps, config)

--- a/src/python/nnfusion/jit.py
+++ b/src/python/nnfusion/jit.py
@@ -133,7 +133,7 @@ def parse_config(tune, tuning_steps, config):
                 "Expected optional 'tune' argument of type bool "
                 "but found {tune}"
             )
-        config['antares_mode'] = True
+        config['antares_mode'] = tune
 
     return config
 

--- a/src/python/nnfusion/jit_utils.py
+++ b/src/python/nnfusion/jit_utils.py
@@ -16,6 +16,8 @@ class TorchModule(torch.nn.Module):
 
 
 def get_signature(obj):
+    return get_primary_signature(obj)
+def get_primary_signature(obj):
     """
     Signature of an object to detect reusable kernel.
     """

--- a/src/python/nnfusion/jit_utils.py
+++ b/src/python/nnfusion/jit_utils.py
@@ -15,11 +15,9 @@ class TorchModule(torch.nn.Module):
         return self.func(*args, **kwargs)
 
 
-def get_signature(obj, suffix=''):
+def get_signature(obj):
     """
-    Signature of a function or torch.nn.Module instance to detect reusable
-    kernel.
-    For details, please refer to https://github.com/microsoft/nnfusion/pull/379
+    Signature of an object to detect reusable kernel.
     """
 
     if isinstance(obj, torch.nn.Module):
@@ -32,15 +30,7 @@ def get_signature(obj, suffix=''):
     ):
         raise Exception(f"Not support type {obj} for get_signature")
 
-    def get_qualname():
-        name = obj.__qualname__
-        # Remove special chars to avoid the trouble of dealing with paths
-        return re.sub("[<>]", "", name)
+    signature = "-".join([obj.__module__, obj.__qualname__])
 
-    def get_path():
-        # Avoid collision between different files
-        obj_path = inspect.getsourcefile(obj)
-        relpath = os.path.relpath(obj_path)
-        return "-".join(Path(os.path.splitext(relpath)[0]).parts)
-
-    return "-".join(('nnf', get_path(), get_qualname())) + suffix
+    # Remove special chars to avoid the trouble of dealing with paths
+    return re.sub("[<>]", "", signature)

--- a/src/python/nnfusion/jit_utils.py
+++ b/src/python/nnfusion/jit_utils.py
@@ -20,6 +20,7 @@ def get_signature(obj):
     Signature of a function or torch.nn.Module instance to detect reusable
     kernel.
     """
+    # For details, please refer to https://github.com/microsoft/nnfusion/pull/379
     def get_qualname():
         if inspect.isfunction(obj) or inspect.ismethod(obj):
             name = obj.__qualname__

--- a/src/python/nnfusion/jit_utils.py
+++ b/src/python/nnfusion/jit_utils.py
@@ -1,3 +1,8 @@
+import inspect
+import os
+import re
+from pathlib import Path
+
 import torch
 
 
@@ -8,3 +13,28 @@ class TorchModule(torch.nn.Module):
 
     def forward(self, *args, **kwargs):
         return self.func(*args, **kwargs)
+
+
+def get_signature(obj):
+    """
+    Signature of a function or torch.nn.Module instance to detect reusable
+    kernel.
+    """
+    def get_qualname():
+        if inspect.isfunction(obj) or inspect.ismethod(obj):
+            name = obj.__qualname__
+        else:
+            name = obj.__class__.__qualname__
+        # Remove special chars to avoid the trouble of dealing with paths
+        return re.sub("[<>]", "", name)
+
+    def get_path():
+        # Avoid collision between different files
+        if inspect.isfunction(obj) or inspect.ismethod(obj):
+            obj_path = inspect.getsourcefile(obj)
+        else:
+            obj_path = inspect.getsourcefile(obj.__class__)
+        relpath = os.path.relpath(obj_path)
+        return "-".join(Path(os.path.splitext(relpath)[0]).parts)
+
+    return "-".join(('nnf', get_path(), get_qualname()))

--- a/src/python/nnfusion/jit_utils.py
+++ b/src/python/nnfusion/jit_utils.py
@@ -16,8 +16,6 @@ class TorchModule(torch.nn.Module):
 
 
 def get_signature(obj):
-    return get_primary_signature(obj)
-def get_primary_signature(obj):
     """
     Signature of an object to detect reusable kernel.
     """

--- a/src/python/nnfusion/jit_utils.py
+++ b/src/python/nnfusion/jit_utils.py
@@ -1,7 +1,5 @@
 import inspect
-import os
 import re
-from pathlib import Path
 
 import torch
 

--- a/src/python/nnfusion/runtime.py
+++ b/src/python/nnfusion/runtime.py
@@ -12,9 +12,7 @@ from .utils import get_sha256_of_file, get_sha256_of_str
 
 
 class NNFusionRT:
-    def __init__(self, model, config, signature,
-                 cache_dir="nnf-kernels",
-                 is_method=False):
+    def __init__(self, model, config, signature, cache_dir="nnf-kernels"):
         """
         Parameters:
             model: the `torch.nn.Module` to be compiled.
@@ -35,8 +33,6 @@ class NNFusionRT:
 
         self.compile_flag = self._get_compile_flag(config)
         self.executor = None
-
-        self.run = self._run_method if is_method else self._run
 
     def compile(self, inputs, outputs):
         """
@@ -97,7 +93,7 @@ class NNFusionRT:
 
         self.executor = Executor(nnf_dir, device=inputs[0].device)
 
-    def _run(self, inputs, outputs, weights=None):
+    def run(self, inputs, outputs, weights=None):
         """
         Perform the computation. The result will be saved in `outputs`.
 
@@ -122,12 +118,12 @@ class NNFusionRT:
         }
         self.executor(in_dict, out_dict, strict=False)
 
-    def _run_method(self, obj, inputs, outputs):
+    def run_method(self, obj, inputs, outputs):
         weights = {
             name: cast_pytorch_tensor(tensor)
             for name, tensor in obj.state_dict().items()
         }
-        return self._run(inputs, outputs, weights)
+        return self.run(inputs, outputs, weights)
 
     def _get_compile_flag(self, config):
         return " ".join([

--- a/src/python/nnfusion/runtime.py
+++ b/src/python/nnfusion/runtime.py
@@ -12,6 +12,14 @@ from .session import build, codegen, modify_nnfusion_rt
 
 class NNFusionRT:
     def __init__(self, model, signature, steps=1000):
+        """
+        Parameters:
+            model: the `torch.nn.Module` to be compiled.
+            signature: signature of model so that we can reuse compiled
+                kernel (if any).
+            steps: number of steps for kernel tuning.
+        """
+
         self.model = model
         self.weight_dict = {
             name: cast_pytorch_tensor(tensor)
@@ -29,6 +37,15 @@ class NNFusionRT:
         self.executor = None
 
     def compile(self, inputs, outputs, force_build=False):
+        """
+        Perform nnfusion codegen and compilation for target input sizes.
+        Skip if a kernel with the same signature is found.
+
+        Parameters:
+            inputs: a list of model inputs.
+            outputs: a list of model outputs.
+            force_build: whether to replace the previous kernel (if any).
+        """
 
         def export_onnx(fname):
             input_names = ["input" + str(i) for i in range(len(inputs))]
@@ -72,6 +89,13 @@ class NNFusionRT:
         self.executor = Executor(self.rt_dir, device=inputs[0].device)
 
     def run(self, inputs, outputs):
+        """
+        Perform the computation. The result will be saved in `outputs`.
+
+        Parameters:
+            inputs: the input tensor(s). Can be a list or tuple.
+            outputs: the output tensor(s). Can be a list or tuple.
+        """
         if not isinstance(inputs, (tuple, list)):
             inputs = [inputs]
         if not isinstance(outputs, (tuple, list)):

--- a/src/python/nnfusion/runtime.py
+++ b/src/python/nnfusion/runtime.py
@@ -1,4 +1,3 @@
-import filecmp
 import os
 import tempfile
 from pathlib import Path
@@ -56,7 +55,7 @@ class NNFusionRT:
 
         def check_if_need_build():
             """
-            Note that this function assume no hash collision 
+            Note that this function assume no hash collision
             """
             need_build = False
 

--- a/src/python/nnfusion/runtime.py
+++ b/src/python/nnfusion/runtime.py
@@ -60,6 +60,9 @@ class NNFusionRT:
             if not os.path.exists(self.onnx_path):
                 return True
 
+            if not os.path.exists(os.path.join(self.rt_dir, 'main_test')):
+                return True
+
             # Compare onnx file to check if modified
             with tempfile.TemporaryDirectory(dir=self.workdir) as tmp:
                 temp_onnx_path = os.path.join(tmp, "temp.onnx")

--- a/src/python/nnfusion/utils.py
+++ b/src/python/nnfusion/utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import os
 import logging
 import subprocess
+import hashlib
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +33,15 @@ def execute(command, redirect_stderr=True, shell=True, **kwargs):
         logger.error(e.output)
         raise e
     return output
+
+
+def get_sha256_of_file(path, max_len=None):
+    hash_sha256 = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_sha256.update(chunk)
+    return hash_sha256.hexdigest()[:max_len]
+
+
+def get_sha256_of_str(string, max_len=None):
+    return hashlib.sha256(string.encode("utf-8")).hexdigest()[:max_len]

--- a/test/python/test_config.py
+++ b/test/python/test_config.py
@@ -5,15 +5,15 @@ def test_config():
     # default
     config = Config()
     assert config['kernel_tuning_steps'] == 1000
-    assert config['function_codegen'] == True
+    assert config['function_codegen'] is True
 
     # init with kwargs
     config = Config(kernel_tuning_steps=42,
                     function_codegen=False,
                     foo=True,)
     assert config['kernel_tuning_steps'] == 42
-    assert config['function_codegen'] == False
-    assert config['foo'] == True
+    assert config['function_codegen'] is False
+    assert config['foo'] is True
 
     # init with dict
     config = Config({
@@ -22,6 +22,5 @@ def test_config():
         'foo': True,
     })
     assert config['kernel_tuning_steps'] == 42
-    assert config['function_codegen'] == False
-    assert config['foo'] == True
-
+    assert config['function_codegen'] is False
+    assert config['foo'] is True

--- a/test/python/test_config.py
+++ b/test/python/test_config.py
@@ -1,0 +1,27 @@
+from nnfusion import Config
+
+
+def test_config():
+    # default
+    config = Config()
+    assert config['kernel_tuning_steps'] == 1000
+    assert config['function_codegen'] == True
+
+    # init with kwargs
+    config = Config(kernel_tuning_steps=42,
+                    function_codegen=False,
+                    foo=True,)
+    assert config['kernel_tuning_steps'] == 42
+    assert config['function_codegen'] == False
+    assert config['foo'] == True
+
+    # init with dict
+    config = Config({
+        'kernel_tuning_steps': 42,
+        'function_codegen': False,
+        'foo': True,
+    })
+    assert config['kernel_tuning_steps'] == 42
+    assert config['function_codegen'] == False
+    assert config['foo'] == True
+

--- a/test/python/test_jit.py
+++ b/test/python/test_jit.py
@@ -5,7 +5,7 @@ from torch.nn import functional as F
 import nnfusion
 
 
-def assert_allclose(output1, output2, rtol=1e-5, atol=1e-8):
+def assert_allclose(output1, output2, rtol=1e-5, atol=1e-5):
 
     if not isinstance(output1, (tuple, list)):
         assert not isinstance(output2, (tuple, list))
@@ -169,26 +169,3 @@ def test_repeat(step):
 
     t = [torch.randn(8, device="cuda") for _ in range(2)]
     compare_torch_and_nrt(func, *t, step=step, run=run)
-
-
-@pytest.mark.xfail(reason=(
-    "Probably some bug when calling nnfusion to compile the same kernel "
-    "in **a single process** (works well for not a single process). "
-    "Not likely to happen in general use (but should work)."))
-def test_keep_signature_but_change_compute_graph():
-    def func(t):
-        return t + t
-    t = torch.randn(8, device="cuda")
-    compare_torch_and_nrt(func, t)
-
-    # just to show that it can pass for compiling another function
-    # TODO delete after fixing bug
-    def func2(t):
-        return t * 8
-    compare_torch_and_nrt(func2, t)
-
-    # same as the first one (identical jit-signature)
-    # to ensure the compiled kernel will be regenerated if graph don't match
-    def func(t):
-        return t * t
-    compare_torch_and_nrt(func, t)

--- a/test/python/test_jit.py
+++ b/test/python/test_jit.py
@@ -134,6 +134,17 @@ def test_jit_class_using_decorator():
     assert_allclose(func(t), model.foo(t))
 
 
+def test_jit_class_using_decorator_multi_instance():
+    @nnfusion.jit
+    class Foo(torch.nn.Linear):
+        pass
+    model1 = Foo(2, 2).cuda().eval()
+    model2 = Foo(2, 2).cuda().eval()
+    t = torch.randn(1, 2, device="cuda")
+    assert_allclose(F.linear(t, model1.weight, model1.bias), model1(t))
+    assert_allclose(F.linear(t, model2.weight, model2.bias), model2(t))
+
+
 def test_jit_class_using_function():
     LinearJIT = nnfusion.jit(torch.nn.Linear)
 

--- a/test/python/test_jit.py
+++ b/test/python/test_jit.py
@@ -142,6 +142,14 @@ def test_jit_class_using_function():
     assert_allclose(F.linear(t, model.weight, model.bias), model(t))
 
 
+def test_jit_with_kwargs():
+    @nnfusion.jit(tune=True, config=nnfusion.Config(kernel_tuning_steps=5))
+    def func(t):
+        return t + t
+    t = torch.randn(8, device="cuda")
+    assert_allclose(t + t, func(t))
+
+
 @pytest.mark.xfail(reason=(
     "nnfusion codegen and compile success exit with 0 "
     "but para_info.json is null"))


### PR DESCRIPTION
As discussed,

**Added**

+ Support JIT for class method (as decorator and as function)
  + ```python
    class Net(...):
        @nnfusion.jit
        def forward(...):
            ...
    ```
  + ```python
    class Net(...):
        def forward(...):
            ...

    model = Net()
    model.forward = nnfusion.jit(model.forward) 
    ```
  + Note that these two approaches are essentially different because all instances share the same JIT wrapper in the former.
+ Support JIT for class
  + is equivalent to JIT `forward`
  + ```python
    @nnfusion.jit
    class Net(...):
        def foo(...):
            ...
        def forward(...):
            ...
    ```
    will have the same behavior as
    ```python
    class Net(...):
        def foo(...):
            ...
        @nnfusion.jit
        def forward(...):
            ...
    ```
+ Implement 3-level signature
  + ```
    |-- object1-signature
    |   |-- model1-hash
    |   |   |-- flag1-hash
    |   |   |   `-- codegen
    |   |   |-- flag2-hash
    |   |   |   `-- codegen
    |   |   `-- model.onnx
    |   `-- model2-hash
    |       |-- flag1-hash
    |       |   `-- codegen
    |       `-- model.onnx
    `-- object2-signature
     ```
+ Add `nnfusion.Config` to fully leverage nnfusion-cli
+ Add NNFusion JIT docs

**Changed**
+ Treat model params as inputs so that different model instances can share the same kernel.
+ Return the object itself if the target object is an instance of `torch.nn.Module` (instead of returning a function).
+ Change the first part of the object's signature from relative path to `__module__`

I'd love to hear your feedback.

#392