### PR TITLE
Refactor onnx tensor loading

### DIFF
--- a/src/nnfusion/common/type/element_type.cpp
+++ b/src/nnfusion/common/type/element_type.cpp
@@ -59,7 +59,7 @@ bool element::Type::nnfusion_element_type_to_dtype_string(const element::Type& n
                                                           std::string& dtype)
 {
     if (ng_et == element::boolean)
-        dtype = "int";
+        dtype = "char";
     else if (ng_et == element::character)
         dtype = "char";
     else if (ng_et == element::f16)

--- a/src/nnfusion/core/kernels/common_langunit.cpp
+++ b/src/nnfusion/core/kernels/common_langunit.cpp
@@ -32,8 +32,4 @@ LU_DEFINE(macro::NNFUSION_DEBUG, "#define NNFUSION_DEBUG\n");
 LU_DEFINE(macro::MIN, "#define MIN(a,b) ((a)>(b)?(b):(a))\n");
 
 // Declaration
-LU_DEFINE(declaration::typedef_int,
-          "\ntypedef signed char int8_t;\ntypedef signed short int16_t;\ntypedef signed int "
-          "int32_t;\ntypedef signed long int int64_t;\ntypedef unsigned char uint8_t;\ntypedef "
-          "unsigned short uint16_t;\ntypedef unsigned int uint32_t;\ntypedef unsigned long int "
-          "uint64_t;\n");
+LU_DEFINE(declaration::typedef_int, "#include <stdint.h>\n");

--- a/src/nnfusion/core/operators/generic_op/generic_op.hpp
+++ b/src/nnfusion/core/operators/generic_op/generic_op.hpp
@@ -279,14 +279,31 @@ namespace nnfusion
         {
             alias_name = alias_name.empty() ? input_name : alias_name;
             config[alias_name] = input_name;
+            // mapping from nnfusion type to antares type
             auto d_type = tensor->get_element_type();
-            if (d_type == element::f32)
+            if (d_type == element::f16)
+            {
+                config[alias_name + "_dtype"] = "float16";
+            }
+            else if (d_type == element::f32)
             {
                 config[alias_name + "_dtype"] = "float32";
             }
             else if (d_type == element::f64)
             {
                 config[alias_name + "_dtype"] = "float64";
+            }
+            else if (d_type == element::boolean)
+            {
+                config[alias_name + "_dtype"] = "int8";
+            }
+            else if (d_type == element::i8)
+            {
+                config[alias_name + "_dtype"] = "int8";
+            }
+            else if (d_type == element::i16)
+            {
+                config[alias_name + "_dtype"] = "int16";
             }
             else if (d_type == element::i32)
             {
@@ -296,17 +313,11 @@ namespace nnfusion
             {
                 config[alias_name + "_dtype"] = "int64";
             }
-            else if (d_type == element::f16)
-            {
-                config[alias_name + "_dtype"] = "float16";
-            }
-            else if (d_type == element::boolean)
-            {
-                config[alias_name + "_dtype"] = "int8";
-            }
             else
             {
-                NNFUSION_CHECK_FAIL() << "Unhandled type: " << d_type;
+                NNFUSION_CHECK_FAIL()
+                    << "Unhandled type: " << d_type
+                    << ", antares currently supports int8/16/32/64, float16/32/64";
             }
             auto shape = tensor->get_shape();
             if (shape.size() == 0)

--- a/src/nnfusion/core/operators/op_define/constant.hpp
+++ b/src/nnfusion/core/operators/op_define/constant.hpp
@@ -52,23 +52,12 @@ namespace nnfusion
             {
                 size_t literal_num = values.size() * sizeof(T) / element_type.size();
 
-                if (element_type == element::f16 && nnfusion::shape_size(m_shape) % 2 == 1)
-                {
-                    OP_VALIDATION(this, values.size() * 4 >= nnfusion::shape_size(m_shape) * 2)
-                        << "Did not get the expected number of literals for a constant of shape "
-                        << m_shape << " (got " << values.size() << ", expected "
-                        << (nnfusion::shape_size(m_shape) == 1 ? "" : "1 or ")
-                        << nnfusion::shape_size(m_shape) << ")." << element_type;
-                }
-                else
-                {
-                    OP_VALIDATION(this,
-                                  literal_num == 1 || literal_num == nnfusion::shape_size(m_shape))
-                        << "Did not get the expected number of literals for a constant of shape "
-                        << m_shape << " (got " << values.size() << ", expected "
-                        << (nnfusion::shape_size(m_shape) == 1 ? "" : "1 or ")
-                        << nnfusion::shape_size(m_shape) << ")." << element_type << sizeof(T);
-                }
+                OP_VALIDATION(this,
+                              literal_num == 1 || literal_num == nnfusion::shape_size(m_shape))
+                    << "Did not get the expected number of literals for a constant of shape "
+                    << m_shape << " (got " << values.size() << ", expected "
+                    << (nnfusion::shape_size(m_shape) == 1 ? "" : "1 or ")
+                    << nnfusion::shape_size(m_shape) << ")." << element_type << sizeof(T);
 
                 if (values.size() == 1)
                 {

--- a/src/nnfusion/frontend/onnx_import/core/tensor.hpp
+++ b/src/nnfusion/frontend/onnx_import/core/tensor.hpp
@@ -65,45 +65,7 @@ namespace nnfusion
                     NNFUSION_CHECK(m_tensor_proto->has_data_type())
                         << "tensor has no data type specified.";
 
-                    switch (m_tensor_proto->data_type())
-                    {
-                    case onnx::TensorProto_DataType::TensorProto_DataType_BOOL: return element::i32;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT:
-                        return element::f32;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
-                        return element::f16;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE:
-                        return element::f64;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_INT8: return element::i8;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_INT16:
-                        return element::i16;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_INT32:
-                        return element::i32;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_INT64:
-                        return element::i64;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_UINT8: return element::u8;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_UINT16:
-                        return element::u16;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_UINT32:
-                        return element::u32;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_UINT64:
-                        return element::u64;
-                    case onnx::TensorProto_DataType::TensorProto_DataType_UNDEFINED:
-                        NNFUSION_CHECK_FAIL() << "data type is not defined";
-                        break;
-                    default:
-                        NNFUSION_CHECK_FAIL()
-                            << "unsupported data type: "
-                            << onnx::TensorProto_DataType_Name(
-                                   onnx::TensorProto_DataType(m_tensor_proto->data_type()));
-                        break;
-                    }
-                    return element::f32;
-                }
-
-                operator onnx::TensorProto_DataType() const
-                {
-                    return onnx::TensorProto_DataType(m_tensor_proto->data_type());
+                    return ONNXDataTypeToNNFusionElementType(m_tensor_proto->data_type());
                 }
 
             private:

--- a/src/nnfusion/frontend/onnx_import/core/value_info.hpp
+++ b/src/nnfusion/frontend/onnx_import/core/value_info.hpp
@@ -71,10 +71,8 @@ namespace nnfusion
                     }
                     NNFUSION_CHECK(m_value_info_proto->type().tensor_type().has_elem_type())
                         << "value info has no element type specified.";
-                    ONNXDataTypeToNNFusionElementType(
-                        onnx::TensorProto_DataType(
-                            m_value_info_proto->type().tensor_type().elem_type()),
-                        &m_type);
+                    m_type = ONNXDataTypeToNNFusionElementType(onnx::TensorProto_DataType(
+                        m_value_info_proto->type().tensor_type().elem_type()));
 
                     if (sym_shape->is_dynamic())
                     {

--- a/src/nnfusion/frontend/onnx_import/op/cast.hpp
+++ b/src/nnfusion/frontend/onnx_import/op/cast.hpp
@@ -39,9 +39,8 @@ namespace nnfusion
                     auto input_gnode = GetInputNode(all_ng_nodes, node_proto, 0);
                     Node node(node_proto);
                     int64_t target_type = node.get_attribute_value<int64_t>("to");
-                    element::Type et_type;
-                    ONNXDataTypeToNNFusionElementType(
-                        static_cast<onnx::TensorProto_DataType>(target_type), &et_type);
+                    element::Type et_type = ONNXDataTypeToNNFusionElementType(
+                        static_cast<onnx::TensorProto_DataType>(target_type));
 
                     auto op = std::make_shared<op::Convert>(et_type);
                     op->set_name(node_proto.output(0));

--- a/src/nnfusion/frontend/onnx_import/op/const_of_shape.hpp
+++ b/src/nnfusion/frontend/onnx_import/op/const_of_shape.hpp
@@ -47,7 +47,7 @@ namespace nnfusion
                     auto value = node.get_attribute_value<Tensor>("value");
                     NNFUSION_CHECK(nnfusion::shape_size(value.get_shape()) == 1);
                     auto const_op =
-                        make_constant_op(onnx::TensorProto_DataType(value),
+                        make_constant_op(value.get_ng_type(),
                                          Shape(std::begin(output_shape), std::end(output_shape)),
                                          value);
 

--- a/src/nnfusion/frontend/onnx_import/op/constant.hpp
+++ b/src/nnfusion/frontend/onnx_import/op/constant.hpp
@@ -32,33 +32,6 @@ namespace nnfusion
         {
             namespace set_1
             {
-                template <typename T>
-                std::shared_ptr<op::Constant> __make_constant_op(const element::Type& type,
-                                                                 const Tensor& tensor)
-                {
-                    return std::make_shared<op::Constant>(
-                        type, tensor.get_shape(), tensor.get_data<T>());
-                }
-
-                const std::map<element::Type,
-                               std::function<std::shared_ptr<op::Constant>(const element::Type&,
-                                                                           const Tensor&)>>&
-                    ONNX_CONST_MAP()
-                {
-                    static const std::map<element::Type,
-                                          std::function<std::shared_ptr<op::Constant>(
-                                              const element::Type&, const Tensor&)>>
-                        the_map = {{element::f32, __make_constant_op<float>},
-                                   {element::f64, __make_constant_op<double>},
-                                   {element::boolean, __make_constant_op<int32_t>},
-                                   {element::i32, __make_constant_op<int32_t>},
-                                   {element::i64, __make_constant_op<int64_t>},
-                                   {element::u32, __make_constant_op<uint32_t>},
-                                   {element::u64, __make_constant_op<uint64_t>}};
-
-                    return the_map;
-                }
-
                 NamedNodeVector TranslateConstantOp(const onnx::NodeProto& node_proto,
                                                     const NodeMap& all_ng_nodes,
                                                     std::shared_ptr<nnfusion::graph::Graph> m_graph)
@@ -66,9 +39,7 @@ namespace nnfusion
                     Node node(node_proto);
                     auto tensor = node.get_attribute_value<Tensor>("value");
 
-                    const auto& func_param = ONNX_CONST_MAP().at(tensor.get_ng_type());
-                    auto op = func_param(tensor.get_ng_type(), tensor);
-
+                    auto op = make_constant_op(tensor);
                     op->set_name(node_proto.output(0));
                     op->set_global_consistent_name(node_proto.output(0));
                     auto gnode = m_graph->add_node_and_edge(op, graph::GNodeVector({}));

--- a/src/nnfusion/frontend/onnx_import/util/graph_convert.cpp
+++ b/src/nnfusion/frontend/onnx_import/util/graph_convert.cpp
@@ -354,9 +354,8 @@ namespace nnfusion
                         move_external_to_rawdata(tensor, model_dir);
                         if (FLAGS_ftraining_mode)
                         {
-                            element::Type type;
-                            ONNXDataTypeToNNFusionElementType(
-                                static_cast<onnx::TensorProto_DataType>(tensor.data_type()), &type);
+                            element::Type type = ONNXDataTypeToNNFusionElementType(
+                                static_cast<onnx::TensorProto_DataType>(tensor.data_type()));
                             std::shared_ptr<graph::GNode> input_gnode;
                             auto tensor_op = std::make_shared<op::Parameter>(
                                 type,
@@ -370,10 +369,8 @@ namespace nnfusion
                         }
                         else
                         {
-                            auto tensor_op = make_constant_op(
-                                static_cast<onnx::TensorProto_DataType>(tensor.data_type()),
-                                Shape(std::begin(tensor.dims()), std::end(tensor.dims())),
-                                Tensor{tensor});
+                            auto wrapper_tensor = Tensor{tensor};
+                            auto tensor_op = make_constant_op(wrapper_tensor);
                             tensor_op->set_name(tensor.name());
                             tensor_op->set_global_consistent_name(tensor.name());
                             auto tensor_gnode =

--- a/src/nnfusion/frontend/onnx_import/util/util.cpp
+++ b/src/nnfusion/frontend/onnx_import/util/util.cpp
@@ -28,97 +28,65 @@ namespace nnfusion
     {
         namespace onnx_import
         {
-            bool ONNXDataTypeToNNFusionElementType(const onnx::TensorProto_DataType onnx_dt,
-                                                   nnfusion::element::Type* nnfusion_et)
+            const nnfusion::element::Type& ONNXDataTypeToNNFusionElementType(int onnx_dt)
             {
                 switch (onnx_dt)
                 {
-                case onnx::TensorProto_DataType::TensorProto_DataType_BOOL:
-                    *nnfusion_et = element::boolean;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT:
-                    *nnfusion_et = element::f32;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
-                    *nnfusion_et = element::f16;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE:
-                    *nnfusion_et = element::f64;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT8:
-                    *nnfusion_et = element::i8;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT16:
-                    *nnfusion_et = element::i16;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT32:
-                    *nnfusion_et = element::i32;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT64:
-                    *nnfusion_et = element::i64;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT8:
-                    *nnfusion_et = element::u8;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT16:
-                    *nnfusion_et = element::u16;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT32:
-                    *nnfusion_et = element::u32;
-                    break;
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT64:
-                    *nnfusion_et = element::u64;
-                    break;
+                case onnx::TensorProto_DataType::TensorProto_DataType_BOOL: return element::boolean;
+                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT: return element::f32;
+                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16: return element::f16;
+                case onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE: return element::f64;
+                case onnx::TensorProto_DataType::TensorProto_DataType_INT8: return element::i8;
+                case onnx::TensorProto_DataType::TensorProto_DataType_INT16: return element::i16;
+                case onnx::TensorProto_DataType::TensorProto_DataType_INT32: return element::i32;
+                case onnx::TensorProto_DataType::TensorProto_DataType_INT64: return element::i64;
+                case onnx::TensorProto_DataType::TensorProto_DataType_UINT8: return element::u8;
+                case onnx::TensorProto_DataType::TensorProto_DataType_UINT16: return element::u16;
+                case onnx::TensorProto_DataType::TensorProto_DataType_UINT32: return element::u32;
+                case onnx::TensorProto_DataType::TensorProto_DataType_UINT64: return element::u64;
                 default:
                     NNFUSION_CHECK_FAIL() << "unsupported onnx element type: "
-                                          << onnx::TensorProto_DataType_Name(onnx_dt);
-                    return false;
+                                          << detail::onnx_type_name(onnx_dt);
                 }
-                return true;
+                return element::f32;
             }
 
-            template <typename T>
-            std::shared_ptr<op::Constant>
-                make_constant_op(const element::Type& type, const Shape shape, const Tensor& tensor)
-            {
-                return std::make_shared<op::Constant>(type, shape, tensor.get_data<T>());
-            }
-
-            std::shared_ptr<op::Constant> make_constant_op(const onnx::TensorProto_DataType onnx_et,
-                                                           const Shape shape,
+            std::shared_ptr<op::Constant> make_constant_op(const element::Type& type,
+                                                           const Shape& shape,
                                                            const Tensor& tensor)
             {
-                switch (onnx_et)
-                {
-                case onnx::TensorProto_DataType::TensorProto_DataType_BOOL:
-                    return make_constant_op<int32_t>(element::i32, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT:
-                    return make_constant_op<float>(element::f32, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16:
-                    return make_constant_op<half_float::half>(element::f16, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_DOUBLE:
-                    return make_constant_op<double>(element::f64, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT8:
-                    return make_constant_op<int8_t>(element::i8, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT16:
-                    return make_constant_op<int16_t>(element::i16, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT32:
-                    return make_constant_op<int32_t>(element::i32, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_INT64:
-                    return make_constant_op<int64_t>(element::i64, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT8:
-                    return make_constant_op<uint8_t>(element::u8, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT16:
-                    return make_constant_op<uint16_t>(element::u16, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT32:
-                    return make_constant_op<uint32_t>(element::u32, shape, tensor);
-                case onnx::TensorProto_DataType::TensorProto_DataType_UINT64:
-                    return make_constant_op<uint64_t>(element::u64, shape, tensor);
-                default:
-                    NNFUSION_CHECK_FAIL() << "unsupported value info element type: "
-                                          << onnx::TensorProto_DataType_Name(onnx_et);
-                }
-                return make_constant_op<float>(element::f32, shape, tensor);
+                if (type == element::boolean)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<char>());
+                if (type == element::i8)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<int8_t>());
+                if (type == element::i16)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<int16_t>());
+                if (type == element::i32)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<int32_t>());
+                if (type == element::i64)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<int64_t>());
+                if (type == element::u8)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<uint8_t>());
+                if (type == element::u16)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<uint16_t>());
+                if (type == element::u32)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<uint32_t>());
+                if (type == element::u64)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<uint64_t>());
+                if (type == element::f16)
+                    return std::make_shared<op::Constant>(
+                        type, shape, tensor.get_data<half_float::half>());
+                if (type == element::f32)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<float>());
+                if (type == element::f64)
+                    return std::make_shared<op::Constant>(type, shape, tensor.get_data<double>());
+                NNFUSION_CHECK_FAIL() << "unsupported element type: " << type;
+                return std::make_shared<op::Constant>(type, shape, tensor.get_data<float>());
+            }
+
+            std::shared_ptr<op::Constant> make_constant_op(const Tensor& tensor)
+            {
+                return make_constant_op(tensor.get_ng_type(), tensor.get_shape(), tensor);
             }
 
             std::shared_ptr<graph::GNode> GetInputNode(const NodeMap& all_ng_nodes,
@@ -136,8 +104,7 @@ namespace nnfusion
                     {
                         return nullptr;
                     }
-                    NNFUSION_CHECK_FAIL() << "Input Ngraph op not found for "
-                                          << node.input(input_idx);
+                    NNFUSION_CHECK_FAIL() << "Input op not found for " << node.input(input_idx);
                 }
                 return result;
             }
@@ -158,8 +125,7 @@ namespace nnfusion
                     {
                         return GNodeIndex{nullptr};
                     }
-                    NNFUSION_CHECK_FAIL() << "Input Ngraph op not found for "
-                                          << node.input(input_idx);
+                    NNFUSION_CHECK_FAIL() << "Input op not found for " << node.input(input_idx);
                 }
                 return result;
             }

--- a/src/nnfusion/frontend/onnx_import/util/util.hpp
+++ b/src/nnfusion/frontend/onnx_import/util/util.hpp
@@ -26,6 +26,7 @@
 #include <iterator>    // std::begin, std::end
 #include <type_traits> // std::enable_if, std::is_floating_point, std::is_integral
 #include <vector>
+#include <bitset>
 
 #include "../onnx_base.hpp"
 #include "nnfusion/common/common.hpp"
@@ -212,15 +213,11 @@ namespace nnfusion
                     // onnx store float16 bit-wise in int32_data
                     if (tensor.data_type() == onnx::TensorProto_DataType_FLOAT16)
                     {
-                        // nnfusion::Shape shape{std::begin(tensor.dims()), std::end(tensor.dims())};
-                        // size_t num_element = shape_size(shape);
                         auto raw = __get_data<int32_t>(tensor.int32_data());
                         std::vector<half_float::half> fp16_data(raw.size());
-                        // cout << "element count: " << num_element << endl;
-                        // cout << "buffer:" << raw.size() << endl;
                         for (size_t i = 0; i < raw.size(); i++)
                         {
-                            NNFUSION_CHECK(raw[i] & 0xFFFF0000 == 0) << "Invalid float16 data";
+                            NNFUSION_CHECK((raw[i] & 0xFFFF0000) == 0) << "Invalid float16 data: " << std::bitset<8*sizeof(raw[i])>(raw[i]);
                             fp16_data[i].set_raw_data(static_cast<uint16_t>(raw[i] & 0x0000FFFF));
                         }
                         return {std::begin(fp16_data), std::end(fp16_data)};

--- a/src/nnfusion/frontend/onnx_import/util/util.hpp
+++ b/src/nnfusion/frontend/onnx_import/util/util.hpp
@@ -21,12 +21,12 @@
 
 #pragma once
 
+#include <bitset>
 #include <cmath>       // std::floor
 #include <cstddef>     // std::size_t
 #include <iterator>    // std::begin, std::end
 #include <type_traits> // std::enable_if, std::is_floating_point, std::is_integral
 #include <vector>
-#include <bitset>
 
 #include "../onnx_base.hpp"
 #include "nnfusion/common/common.hpp"
@@ -217,7 +217,9 @@ namespace nnfusion
                         std::vector<half_float::half> fp16_data(raw.size());
                         for (size_t i = 0; i < raw.size(); i++)
                         {
-                            NNFUSION_CHECK((raw[i] & 0xFFFF0000) == 0) << "Invalid float16 data: " << std::bitset<8*sizeof(raw[i])>(raw[i]);
+                            NNFUSION_CHECK((raw[i] & 0xFFFF0000) == 0)
+                                << "Invalid float16 data: "
+                                << std::bitset<8 * sizeof(raw[i])>(raw[i]);
                             fp16_data[i].set_raw_data(static_cast<uint16_t>(raw[i] & 0x0000FFFF));
                         }
                         return {std::begin(fp16_data), std::end(fp16_data)};

--- a/src/nnfusion/frontend/onnx_import/util/util.hpp
+++ b/src/nnfusion/frontend/onnx_import/util/util.hpp
@@ -36,8 +36,72 @@ namespace nnfusion
     {
         namespace onnx_import
         {
+            class Tensor;
+            class Node;
+
+            const nnfusion::element::Type& ONNXDataTypeToNNFusionElementType(int onnx_dt);
+
+            std::shared_ptr<op::Constant> make_constant_op(const element::Type& type,
+                                                           const Shape& shape,
+                                                           const Tensor& tensor);
+
+            std::shared_ptr<op::Constant> make_constant_op(const Tensor& tensor);
+
+            std::shared_ptr<graph::GNode> GetInputNode(const NodeMap& all_ng_nodes,
+                                                       const onnx::NodeProto& node,
+                                                       size_t input_idx);
+
+            nnfusion::graph::GNodeIndex GetInputIndex(const NodeMap& all_ng_nodes,
+                                                      const onnx::NodeProto& node,
+                                                      size_t input_idx);
+
+            graph::GNodeVector GetAllInputNode(const NodeMap& all_ng_nodes,
+                                               const onnx::NodeProto& node);
+
+            GNodeIndexVector GetAllInputIndex(const NodeMap& all_ng_nodes,
+                                              const onnx::NodeProto& node);
+
             namespace detail
             {
+                inline bool is_int_type(int type)
+                {
+                    return type == onnx::TensorProto_DataType_BOOL ||
+                           type == onnx::TensorProto_DataType_UINT8 ||
+                           type == onnx::TensorProto_DataType_UINT16 ||
+                           type == onnx::TensorProto_DataType_UINT32 ||
+                           type == onnx::TensorProto_DataType_UINT64 ||
+                           type == onnx::TensorProto_DataType_INT8 ||
+                           type == onnx::TensorProto_DataType_INT16 ||
+                           type == onnx::TensorProto_DataType_INT32 ||
+                           type == onnx::TensorProto_DataType_INT64;
+                }
+
+                inline bool is_float_type(int type)
+                {
+                    return type == onnx::TensorProto_DataType_FLOAT ||
+                           type == onnx::TensorProto_DataType_FLOAT16 ||
+                           type == onnx::TensorProto_DataType_DOUBLE ||
+                           type == onnx::TensorProto_DataType_BFLOAT16;
+                }
+
+                inline bool is_str_type(int type)
+                {
+                    return type == onnx::TensorProto_DataType_STRING;
+                }
+
+                inline bool is_complex_type(int type)
+                {
+                    return type == onnx::TensorProto_DataType_COMPLEX64 ||
+                           type == onnx::TensorProto_DataType_COMPLEX128;
+                }
+
+                inline std::string onnx_type_name(int type)
+                {
+                    static auto desc = onnx::TensorProto_DataType_descriptor();
+                    std::string type_name = desc->FindValueByNumber(type)->name();
+                    return type_name;
+                }
+
                 template <typename T, typename Container>
                 inline std::vector<T> __get_data(const Container& container)
                 {
@@ -56,211 +120,191 @@ namespace nnfusion
                 {
                     NNFUSION_CHECK_FAIL()
                         << tensor.name() << " "
-                        << "unsupported data type: "
-                        << static_cast<onnx::TensorProto_DataType>(tensor.data_type());
+                        << "unsupported data type: " << onnx_type_name(tensor.data_type());
+                    return std::vector<T>();
+                }
+
+                template <typename T, unsigned int W = sizeof(T)>
+                inline std::vector<T> __get_int_data(const onnx::TensorProto& tensor)
+                {
+                    if (!is_int_type(tensor.data_type()))
+                    {
+                        NNFUSION_CHECK_FAIL()
+                            << "Unsupported conversion, target type: "
+                            << element::from<T>().c_type_string()
+                            << ", onnx type: " << onnx_type_name(tensor.data_type());
+                    }
+
+                    // forbid narrowing conversions
+                    nnfusion::element::Type ele_type =
+                        ONNXDataTypeToNNFusionElementType(tensor.data_type());
+                    if (ele_type.size() > W)
+                    {
+                        NNFUSION_CHECK_FAIL()
+                            << "Unsupported narrowing conversion, target type: "
+                            << element::from<T>().c_type_string()
+                            << ", onnx type: " << onnx_type_name(tensor.data_type());
+                    }
+
+                    if (tensor.has_raw_data())
+                    {
+                        return __get_raw_data<T>(tensor.raw_data());
+                    }
+
+                    if (tensor.data_type() == onnx::TensorProto_DataType_BOOL ||
+                        tensor.data_type() == onnx::TensorProto_DataType_UINT8 ||
+                        tensor.data_type() == onnx::TensorProto_DataType_INT8 ||
+                        tensor.data_type() == onnx::TensorProto_DataType_UINT16 ||
+                        tensor.data_type() == onnx::TensorProto_DataType_INT16 ||
+                        tensor.data_type() == onnx::TensorProto_DataType_INT32)
+                    {
+                        return __get_data<T>(tensor.int32_data());
+                    }
+
+                    if (tensor.data_type() == onnx::TensorProto_DataType_UINT32 ||
+                        tensor.data_type() == onnx::TensorProto_DataType_UINT64)
+                    {
+                        return __get_data<T>(tensor.uint64_data());
+                    }
+
+                    if (tensor.data_type() == onnx::TensorProto_DataType_INT64)
+                    {
+                        return __get_data<T>(tensor.int64_data());
+                    }
+
+                    NNFUSION_CHECK_FAIL() << "invalid data type: "
+                                          << onnx_type_name(tensor.data_type());
+                    return std::vector<T>();
+                }
+
+                template <typename T, unsigned int W = sizeof(T)>
+                inline std::vector<T> __get_float_data(const onnx::TensorProto& tensor)
+                {
+                    if (tensor.data_type() == onnx::TensorProto_DataType_BFLOAT16)
+                    {
+                        NNFUSION_CHECK_FAIL() << "BF16 not support yet";
+                    }
+
+                    if (!is_float_type(tensor.data_type()))
+                    {
+                        NNFUSION_CHECK_FAIL()
+                            << "Unsupported conversion, target type: "
+                            << element::from<T>().c_type_string()
+                            << ", onnx type: " << onnx_type_name(tensor.data_type());
+                    }
+
+                    // forbid narrowing conversions
+                    nnfusion::element::Type ele_type =
+                        ONNXDataTypeToNNFusionElementType(tensor.data_type());
+                    if (ele_type.size() > W)
+                    {
+                        NNFUSION_CHECK_FAIL()
+                            << "Unsupported narrowing conversion, target type: "
+                            << element::from<T>().c_type_string()
+                            << ", onnx type: " << onnx_type_name(tensor.data_type());
+                    }
+
+                    if (tensor.has_raw_data())
+                    {
+                        return __get_raw_data<T>(tensor.raw_data());
+                    }
+
+                    // onnx store float16 bit-wise in int32_data
+                    if (tensor.data_type() == onnx::TensorProto_DataType_FLOAT16)
+                    {
+                        // nnfusion::Shape shape{std::begin(tensor.dims()), std::end(tensor.dims())};
+                        // size_t num_element = shape_size(shape);
+                        auto raw = __get_data<int32_t>(tensor.int32_data());
+                        std::vector<half_float::half> fp16_data(raw.size());
+                        // cout << "element count: " << num_element << endl;
+                        // cout << "buffer:" << raw.size() << endl;
+                        for (size_t i = 0; i < raw.size(); i++)
+                        {
+                            NNFUSION_CHECK(raw[i] & 0xFFFF0000 == 0) << "Invalid float16 data";
+                            fp16_data[i].set_raw_data(static_cast<uint16_t>(raw[i] & 0x0000FFFF));
+                        }
+                        return {std::begin(fp16_data), std::end(fp16_data)};
+                    }
+
+                    if (tensor.data_type() == onnx::TensorProto_DataType_FLOAT)
+                    {
+                        return __get_data<T>(tensor.float_data());
+                    }
+
+                    if (tensor.data_type() == onnx::TensorProto_DataType_DOUBLE)
+                    {
+                        return __get_data<T>(tensor.double_data());
+                    }
+
+                    NNFUSION_CHECK_FAIL() << "invalid data type: "
+                                          << onnx_type_name(tensor.data_type());
                     return std::vector<T>();
                 }
 
                 template <>
-                inline std::vector<char> get_data(const onnx::TensorProto& tensor)
+                inline std::vector<int8_t> get_data(const onnx::TensorProto& tensor)
                 {
-                    if (tensor.has_raw_data())
-                    {
-                        return __get_raw_data<char>(tensor.raw_data());
-                    }
-
-                    if (tensor.data_type() == onnx::TensorProto_DataType_BOOL)
-                    {
-                        return __get_data<char>(tensor.int32_data());
-                    }
-
-                    if (tensor.data_type() == onnx::TensorProto_DataType_UINT8)
-                    {
-                        return __get_data<char>(tensor.int32_data());
-                    }
-
-                    if (tensor.data_type() == onnx::TensorProto_DataType_INT8)
-                    {
-                        return __get_data<char>(tensor.int32_data());
-                    }
-
-                    NNFUSION_CHECK_FAIL()
-                        << "invalid data type: "
-                        << onnx::TensorProto_DataType_Name(
-                               static_cast<onnx::TensorProto_DataType>(tensor.data_type()));
-                    return std::vector<char>();
+                    return __get_int_data<int8_t>(tensor);
                 }
 
                 template <>
-                inline std::vector<float> get_data(const onnx::TensorProto& tensor)
+                inline std::vector<uint8_t> get_data(const onnx::TensorProto& tensor)
                 {
-                    if (tensor.has_raw_data())
-                    {
-                        return __get_raw_data<float>(tensor.raw_data());
-                    }
-
-                    if (tensor.data_type() == onnx::TensorProto_DataType_FLOAT16)
-                    {
-                        nnfusion::Shape shape{std::begin(tensor.dims()), std::end(tensor.dims())};
-                        size_t num_element = shape_size(shape);
-                        std::vector<int32_t> raw_data = __get_data<int32_t>(tensor.int32_data());
-                        std::vector<float> ret((num_element + 1) / 2, 0.0);
-                        uint32_t* src_p = (uint32_t*)raw_data.data();
-                        uint16_t* dst_p = (uint16_t*)ret.data();
-                        for (size_t i = 0; i < num_element; i++)
-                        {
-                            NNFUSION_CHECK((src_p[i] & 0xFFFF0000) == 0);
-                            dst_p[i] = src_p[i] & 0x0000FFFF;
-                        }
-                        if (num_element % 2 == 1)
-                        {
-                            dst_p[num_element] = 0;
-                        }
-
-                        return ret;
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_FLOAT)
-                    {
-                        return __get_data<float>(tensor.float_data());
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_INT32)
-                    {
-                        return __get_data<float>(tensor.int32_data());
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_INT64)
-                    {
-                        return __get_data<float>(tensor.int64_data());
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_UINT64)
-                    {
-                        return __get_data<float>(tensor.uint64_data());
-                    }
-                    NNFUSION_CHECK_FAIL()
-                        << "invalid data type: "
-                        << onnx::TensorProto_DataType_Name(
-                               static_cast<onnx::TensorProto_DataType>(tensor.data_type()));
-                    return std::vector<float>();
+                    return __get_int_data<uint8_t>(tensor);
                 }
 
                 template <>
-                inline std::vector<half_float::half> get_data(const onnx::TensorProto& tensor)
+                inline std::vector<int16_t> get_data(const onnx::TensorProto& tensor)
                 {
-                    if (tensor.has_raw_data())
-                    {
-                        return __get_raw_data<half_float::half>(tensor.raw_data());
-                    }
-                    else
-                    {
-                        NNFUSION_LOG(NNFUSION_WARNING) << "Have no raw data" << endl;
-                    }
+                    return __get_int_data<int16_t>(tensor);
+                }
 
-                    if (tensor.data_type() == onnx::TensorProto_DataType_FLOAT16)
-                    {
-                        nnfusion::Shape shape{std::begin(tensor.dims()), std::end(tensor.dims())};
-                        size_t num_element = shape_size(shape);
-                        std::vector<int32_t> raw_data = __get_data<int32_t>(tensor.int32_data());
-                        std::vector<half_float::half> ret(num_element);
-                        uint32_t* src_p = (uint32_t*)raw_data.data();
-                        uint16_t* dst_p = (uint16_t*)ret.data();
-                        for (size_t i = 0; i < num_element; i++)
-                        {
-                            NNFUSION_CHECK((src_p[i] & 0xFFFF0000) == 0);
-                            dst_p[i] = src_p[i] & 0x0000FFFF;
-                        }
-
-                        return ret;
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_FLOAT)
-                    {
-                        return __get_data<half_float::half>(tensor.float_data());
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_INT32)
-                    {
-                        return __get_data<half_float::half>(tensor.int32_data());
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_INT64)
-                    {
-                        return __get_data<half_float::half>(tensor.int64_data());
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_UINT64)
-                    {
-                        return __get_data<half_float::half>(tensor.uint64_data());
-                    }
-                    NNFUSION_CHECK_FAIL()
-                        << "invalid data type: "
-                        << onnx::TensorProto_DataType_Name(
-                               static_cast<onnx::TensorProto_DataType>(tensor.data_type()));
-                    return std::vector<half_float::half>();
+                template <>
+                inline std::vector<uint16_t> get_data(const onnx::TensorProto& tensor)
+                {
+                    return __get_int_data<uint16_t>(tensor);
                 }
 
                 template <>
                 inline std::vector<int32_t> get_data(const onnx::TensorProto& tensor)
                 {
-                    if (tensor.data_type() == onnx::TensorProto_DataType_BOOL)
-                    {
-                        // onnx store bool in byte
-                        std::vector<int32_t> res;
-                        if (tensor.has_raw_data())
-                        {
-                            res = __get_raw_data<int32_t>(tensor.raw_data());
-                        }
-                        else
-                        {
-                            res = __get_data<int32_t>(tensor.int32_data());
-                        }
-                        NNFUSION_CHECK(res.size() > 0);
-                        nnfusion::Shape shape{std::begin(tensor.dims()), std::end(tensor.dims())};
-                        size_t num_element = shape_size(shape);
-                        char* raw_p = reinterpret_cast<char*>(res.data());
-                        std::vector<int32_t> ret;
-                        ret.reserve(num_element);
-                        for (size_t i = 0; i < num_element; i++)
-                        {
-                            ret.push_back(raw_p[i]);
-                        }
-                        return ret;
-                    }
-                    if (tensor.data_type() == onnx::TensorProto_DataType_INT32)
-                    {
-                        if (tensor.has_raw_data())
-                        {
-                            return __get_raw_data<int32_t>(tensor.raw_data());
-                        }
-                        else
-                        {
-                            return __get_data<int32_t>(tensor.int32_data());
-                        }
-                    }
-                    NNFUSION_CHECK_FAIL() << "invalid data type: "
-                                          << onnx::TensorProto_DataType_Name(
-                                                 onnx::TensorProto_DataType(tensor.data_type()));
-                    return std::vector<int32_t>();
+                    return __get_int_data<int32_t>(tensor);
+                }
+
+                template <>
+                inline std::vector<uint32_t> get_data(const onnx::TensorProto& tensor)
+                {
+                    return __get_int_data<uint32_t>(tensor);
                 }
 
                 template <>
                 inline std::vector<int64_t> get_data(const onnx::TensorProto& tensor)
                 {
-                    if (tensor.has_raw_data())
-                    {
-                        return __get_raw_data<int64_t>(tensor.raw_data());
-                    }
-                    NNFUSION_CHECK(tensor.data_type() == onnx::TensorProto_DataType_INT64);
-
-                    return __get_data<int64_t>(tensor.int64_data());
+                    return __get_int_data<int64_t>(tensor);
                 }
 
                 template <>
                 inline std::vector<uint64_t> get_data(const onnx::TensorProto& tensor)
                 {
-                    if (tensor.has_raw_data())
-                    {
-                        return __get_raw_data<uint64_t>(tensor.raw_data());
-                    }
-                    NNFUSION_CHECK(tensor.data_type() == onnx::TensorProto_DataType_UINT64)
-                        << "invalid data type: "
-                        << onnx::TensorProto_DataType_Name(
-                               static_cast<onnx::TensorProto_DataType>(tensor.data_type()));
-                    return __get_data<uint64_t>(tensor.uint64_data());
+                    return __get_int_data<uint64_t>(tensor);
+                }
+
+                template <>
+                inline std::vector<half_float::half> get_data(const onnx::TensorProto& tensor)
+                {
+                    return __get_float_data<half_float::half>(tensor);
+                }
+
+                template <>
+                inline std::vector<float> get_data(const onnx::TensorProto& tensor)
+                {
+                    return __get_float_data<float>(tensor);
+                }
+
+                template <>
+                inline std::vector<double> get_data(const onnx::TensorProto& tensor)
+                {
+                    return __get_float_data<double>(tensor);
                 }
 
                 /// \brief      Fill specified range with monotonic sequence.
@@ -285,35 +329,6 @@ namespace nnfusion
                     }
                 }
             }
-
-            class Tensor;
-            class Node;
-
-            bool ONNXDataTypeToNNFusionElementType(const onnx::TensorProto_DataType onnx_dt,
-                                                   nnfusion::element::Type* nnfusion_et);
-
-            template <typename T>
-            std::shared_ptr<op::Constant> make_constant_op(const element::Type& type,
-                                                           const Shape shape,
-                                                           const Tensor& tensor);
-
-            std::shared_ptr<op::Constant> make_constant_op(const onnx::TensorProto_DataType onnx_et,
-                                                           const Shape shape,
-                                                           const Tensor& tensor);
-
-            std::shared_ptr<graph::GNode> GetInputNode(const NodeMap& all_ng_nodes,
-                                                       const onnx::NodeProto& node,
-                                                       size_t input_idx);
-
-            nnfusion::graph::GNodeIndex GetInputIndex(const NodeMap& all_ng_nodes,
-                                                      const onnx::NodeProto& node,
-                                                      size_t input_idx);
-
-            graph::GNodeVector GetAllInputNode(const NodeMap& all_ng_nodes,
-                                               const onnx::NodeProto& node);
-
-            GNodeIndexVector GetAllInputIndex(const NodeMap& all_ng_nodes,
-                                              const onnx::NodeProto& node);
 
             /// \brief      Return the monotonic sequence.
             ///


### PR DESCRIPTION
Refactor loading onnx constant/initializers:
1. Supported type:
    -   Integer type: bool/int8/uint8/int16/uint16/int32/uint32/int64/uint64
    -    Floating type: float16/float32/float64
2. Known unsupported type: complex/string/bf16
3. Forbid numeric type conversion, e.g. onnx store in int but nnfusion requires as float
4. Forbid narrowing loading, e.g. int64->int32

Update antares type mapping, antares supports only int8/16/32/64 and float16/32/64
