### PR TITLE
fix argmax/argmin missing arguments in tensorflow import unitest 

### DIFF
--- a/src/nnfusion/core/operators/generic_op/generic_op_define/ArgMin.cpp
+++ b/src/nnfusion/core/operators/generic_op/generic_op_define/ArgMin.cpp
@@ -9,10 +9,10 @@ REGISTER_OP(ArgMin)
         {
             NNFUSION_CHECK(2 == gnode->get_input_size());
             auto& input_shape = gnode->get_input_shape(0);
-            auto _op = static_pointer_cast<nnfusion::op::ArgMax>(gnode->get_op_ptr());
+            auto _op = static_pointer_cast<nnfusion::op::ArgMin>(gnode->get_op_ptr());
             auto axis = _op->get_reduction_axis();
             if (axis >= input_shape.size())
-                NNFUSION_CHECK_FAIL() << "ArgMax: axis out of range";
+                NNFUSION_CHECK_FAIL() << "ArgMin: axis out of range";
             nnfusion::Shape output_shape_0;
             for (int i = 0; i < input_shape.size(); ++i)
             {
@@ -34,12 +34,12 @@ REGISTER_OP(ArgMin)
                 return "[" + (axis.empty() ? "N" : ret.substr(2)) + "]";
             };
 
-            auto _op = static_pointer_cast<nnfusion::op::ArgMax>(curr->get_op_ptr());
+            auto _op = static_pointer_cast<nnfusion::op::ArgMin>(curr->get_op_ptr());
             auto input_shape = curr->get_input_shape(0);
             auto axis = _op->get_reduction_axis();
             auto select_last_index = _op->get_select_last_index();
             if (axis >= input_shape.size())
-                NNFUSION_CHECK_FAIL() << "ArgMax: axis out of range";
+                NNFUSION_CHECK_FAIL() << "ArgMin: axis out of range";
 
             auto output_shape = curr->get_output_shape(0);
             auto output_datatype = curr->get_output_element_type(0);

--- a/test/nnfusion/inventory/arg_max.cpp
+++ b/test/nnfusion/inventory/arg_max.cpp
@@ -29,7 +29,7 @@ namespace nnfusion
                 Shape shape{4, 3};
                 auto A = make_shared<op::Parameter>(element::f32, shape);
                 auto A_gnode = graph->add_node_and_edge(A, GNodeVector({}));
-                auto r = make_shared<op::ArgMax>(0, element::f32);
+                auto r = make_shared<op::ArgMax>(0, 0, 0, element::f32);
                 auto r_gnode = graph->add_node_and_edge(r, {A_gnode});
                 return r_gnode;
             }
@@ -39,7 +39,7 @@ namespace nnfusion
                 Shape shape{2, 2, 5, 5};
                 auto A = make_shared<op::Parameter>(element::f32, shape);
                 auto A_gnode = graph->add_node_and_edge(A, GNodeVector({}));
-                auto r = make_shared<op::ArgMax>(3, element::f32);
+                auto r = make_shared<op::ArgMax>(3, 0, 0, element::f32);
                 auto r_gnode = graph->add_node_and_edge(r, {A_gnode});
                 return r_gnode;
             }

--- a/test/nnfusion/inventory/arg_min.cpp
+++ b/test/nnfusion/inventory/arg_min.cpp
@@ -29,7 +29,7 @@ namespace nnfusion
                 Shape shape{4, 3};
                 auto A = make_shared<op::Parameter>(element::f32, shape);
                 auto A_gnode = graph->add_node_and_edge(A, GNodeVector({}));
-                auto r = make_shared<op::ArgMin>(0, element::f32);
+                auto r = make_shared<op::ArgMin>(0, 0, 0, element::f32);
                 auto r_gnode = graph->add_node_and_edge(r, {A_gnode});
                 return r_gnode;
             }
@@ -39,7 +39,7 @@ namespace nnfusion
                 Shape shape{2, 2, 5, 5};
                 auto A = make_shared<op::Parameter>(element::f32, shape);
                 auto A_gnode = graph->add_node_and_edge(A, GNodeVector({}));
-                auto r = make_shared<op::ArgMin>(3, element::f32);
+                auto r = make_shared<op::ArgMin>(3, 0, 0, element::f32);
                 auto r_gnode = graph->add_node_and_edge(r, {A_gnode});
                 return r_gnode;
             }


### PR DESCRIPTION
1. fix argmax/argmin missing arguments in tensorflow import unitest.
2. fix typo in src/nnfusion/core/operators/generic_op/generic_op_define/ArgMin.cpp
