### PR TITLE
[Bug fix] Register Fusion Pass fuse policy assign wrong output edges

### DIFF
--- a/src/nnfusion/core/kernels/cuda_gpu/cuda_langunit.cpp
+++ b/src/nnfusion/core/kernels/cuda_gpu/cuda_langunit.cpp
@@ -295,6 +295,15 @@ __device__ __forceinline__ half  load(const half*  __restrict__ in, int i=0, boo
     }
     return v;
 }
+__device__ __forceinline__ int16_t  load(const int16_t*  __restrict__ in, int i=0, bool b=true)
+{
+    int16_t v = 0;
+    if (b)
+    {
+        v = __ldg(in + i);
+    }
+    return v;
+}
 __device__ __forceinline__ int32_t  load(const int32_t*  __restrict__ in, int i=0, bool b=true)
 {
     int32_t v = 0;

--- a/src/nnfusion/engine/pass/graph/register_fusion_pass.cpp
+++ b/src/nnfusion/engine/pass/graph/register_fusion_pass.cpp
@@ -417,7 +417,7 @@ public:
                     auto out_node = out_edge->get_dst();
                     if (node_set.count(out_node))
                         continue;
-                    m_graph->add_edge(fused_node, out_id, out_node, out_edge->get_dst_input());
+                    m_graph->add_edge(fused_node, i, out_node, out_edge->get_dst_input());
                 }
             }
             // cleanup


### PR DESCRIPTION
1. Add Support for int16_t load ( bloom fp16 model
2. for fused node with multiple outputs, this will cause incorrect results.